### PR TITLE
ROSパラメータでGPIOの番号を設定する。これは旧基板に対応するための機能です

### DIFF
--- a/frootspi_examples/launch/hardware.launch.py
+++ b/frootspi_examples/launch/hardware.launch.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
 from launch.actions import RegisterEventHandler
@@ -22,6 +24,12 @@ from launch_ros.descriptions import ComposableNode
 
 
 def generate_launch_description():
+    gpio_config = os.path.join(
+        get_package_share_directory('frootspi_hardware'),
+        'config',
+        'gpio.yaml'
+    )
+
     container = ComposableNodeContainer(
         name='frootspi_container',
         namespace='',
@@ -32,6 +40,7 @@ def generate_launch_description():
                 package='frootspi_hardware',
                 plugin='frootspi_hardware::Driver',
                 name='hardware_driver',
+                parameters=[gpio_config],
                 extra_arguments=[{'use_intra_process_comms': True}],
                 ),
         ],

--- a/frootspi_hardware/CMakeLists.txt
+++ b/frootspi_hardware/CMakeLists.txt
@@ -75,6 +75,10 @@ install(TARGETS
   driver_node
   DESTINATION lib/${PROJECT_NAME})
 
+install(DIRECTORY
+  config
+  DESTINATION share/${PROJECT_NAME}/)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/frootspi_hardware/config/gpio.yaml
+++ b/frootspi_hardware/config/gpio.yaml
@@ -1,0 +1,1 @@
+gpio_ball_sensor: 6

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -105,6 +105,7 @@ private:
   rclcpp::TimerBase::SharedPtr polling_timer_;
 
   int pi_;
+  int gpio_ball_sensor_;
 };
 
 }  // namespace frootspi_hardware

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -45,7 +45,7 @@ void Driver::on_polling_timer()
 {
   // ボール検出をパブリッシュ
   auto ball_detection_msg = std::make_unique<frootspi_msgs::msg::BallDetection>();
-  ball_detection_msg->detected = gpio_read(pi_, 6);  // 検出したらtrueをセット
+  ball_detection_msg->detected = gpio_read(pi_, gpio_ball_sensor_);
   pub_ball_detection_->publish(std::move(ball_detection_msg));
 
   // バッテリー電圧をパブリッシュ
@@ -210,10 +210,15 @@ CallbackReturn Driver::on_configure(const rclcpp_lifecycle::State &)
     RCLCPP_ERROR(this->get_logger(), "Failed to connect pigpiod.");
     return CallbackReturn::FAILURE;
   }
+
+  declare_parameter("gpio_ball_sensor", 6);
+  gpio_ball_sensor_ = get_parameter("gpio_ball_sensor").get_value<int>();
+
+
   // add pigpio port setting
   // ball sensor setup
-  set_mode(pi_, 6, PI_INPUT);
-  set_pull_up_down(pi_, 6, PI_PUD_UP);
+  set_mode(pi_, gpio_ball_sensor_, PI_INPUT);
+  set_pull_up_down(pi_, gpio_ball_sensor_, PI_PUD_UP);
 
   return CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
- 旧基板ではGPIO22にボールセンサが接続されています。
- ソースコードを変更せずに（コンパイル無しで）GPIOを変更するためros paramの機能を使用します。
  - `frootspi_hardware/config/gpio.yaml`内の`gpio_ball_sensor`を変更します
- 旧基板と新基板で同じGPIOを使用する機能については、`gpio.yaml`にパラメータを設定する必要はありません。