### PR TITLE
hardware_driverにホイール制御を追加

### DIFF
--- a/frootspi_examples/launch/hardware.launch.py
+++ b/frootspi_examples/launch/hardware.launch.py
@@ -47,6 +47,18 @@ def generate_launch_description():
         output='screen',
     )
 
+    start_pigpiod = ExecuteProcess(
+        cmd=['sudo pigpiod'],
+        shell=True,
+        output='screen',
+    )
+
+    start_socket_can0 = ExecuteProcess(
+        cmd=['sudo ip link set can0 up type can bitrate 1000000'],
+        shell=True,
+        output='screen',
+    )
+
     configure_node = ExecuteProcess(
         cmd=['ros2 lifecycle set hardware_driver configure'],
         shell=True,
@@ -60,6 +72,8 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
+        start_pigpiod,
+        start_socket_can0,
         RegisterEventHandler(
             event_handler=OnProcessStart(
                 target_action=container,

--- a/frootspi_hardware/CMakeLists.txt
+++ b/frootspi_hardware/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(include)
 add_library(driver_component SHARED
   src/driver_component.cpp
   src/io_expander.cpp
+  src/wheel_controller.cpp
 )
 target_compile_definitions(driver_component
   PRIVATE "FROOTSPI_HARDWARE_BUILDING_DLL")

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -21,6 +21,7 @@
 
 #include "frootspi_hardware/visibility_control.h"
 #include "frootspi_hardware/io_expander.hpp"
+#include "frootspi_hardware/wheel_controller.hpp"
 #include "frootspi_msgs/msg/ball_detection.hpp"
 #include "frootspi_msgs/msg/battery_voltage.hpp"
 #include "frootspi_msgs/msg/dribble_power.hpp"
@@ -108,6 +109,7 @@ private:
   int pi_;
   int gpio_ball_sensor_;
   IOExpander io_expander_;
+  WheelController wheel_controller_;
 };
 
 }  // namespace frootspi_hardware

--- a/frootspi_hardware/include/frootspi_hardware/wheel_controller.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/wheel_controller.hpp
@@ -1,0 +1,34 @@
+// Copyright 2021 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FROOTSPI_HARDWARE__WHEEL_CONTROLLER_HPP_
+#define FROOTSPI_HARDWARE__WHEEL_CONTROLLER_HPP_
+
+class WheelController
+{
+public:
+  WheelController();
+  ~WheelController();
+
+  bool device_open();
+  bool device_close();
+  bool set_wheel_velocities(
+    const double vel_front_right, const double vel_front_left,
+    const double vel_back_center);
+
+private:
+  int socket_;
+};
+
+#endif  // FROOTSPI_HARDWARE__WHEEL_CONTROLLER_HPP_

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -98,9 +98,8 @@ void Driver::callback_dribble_power(const frootspi_msgs::msg::DribblePower::Shar
 
 void Driver::callback_wheel_velocities(const frootspi_msgs::msg::WheelVelocities::SharedPtr msg)
 {
-  std::cout << "車輪目標回転速度は、左前" << std::to_string(msg->front_left);
-  std::cout << "、真ん中後" << std::to_string(msg->back_center);
-  std::cout << "、右前" << std::to_string(msg->back_center) << std::endl;
+  wheel_controller_.set_wheel_velocities(
+    msg->front_right, msg->front_left, msg->back_center);
 }
 
 void Driver::on_kick(
@@ -226,6 +225,11 @@ CallbackReturn Driver::on_configure(const rclcpp_lifecycle::State &)
 
   if (!io_expander_.open(pi_)) {
     RCLCPP_ERROR(this->get_logger(), "Failed to connect IO expander.");
+    return CallbackReturn::FAILURE;
+  }
+
+  if (!wheel_controller_.device_open()) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to connect wheel controller.");
     return CallbackReturn::FAILURE;
   }
 

--- a/frootspi_hardware/src/wheel_controller.cpp
+++ b/frootspi_hardware/src/wheel_controller.cpp
@@ -84,7 +84,7 @@ bool WheelController::device_close()
 bool WheelController::set_wheel_velocities(
   const double vel_front_right, const double vel_front_left, const double vel_back_center)
 {
-  constexpr double GEAR_RAITO = 2.2/1.091;  // この数値はモタドラと帳尻を合わせること
+  constexpr double GEAR_RAITO = 2.2 / 1.091;  // この数値はモタドラと帳尻を合わせること
   constexpr double LSB = 10;  // 送信データの1bitが、モータ速度の10倍を表す
   constexpr double WHEEL_TO_MOTOR = GEAR_RAITO * LSB;
 

--- a/frootspi_hardware/src/wheel_controller.cpp
+++ b/frootspi_hardware/src/wheel_controller.cpp
@@ -1,0 +1,114 @@
+// Copyright 2021 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+#include "frootspi_hardware/wheel_controller.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("wheel_controller");
+
+WheelController::WheelController()
+: socket_(-1)
+{
+}
+
+WheelController::~WheelController()
+{
+  device_close();
+}
+
+bool WheelController::device_open()
+{
+  // ソケットの生成
+  // Protocol Family  : CAN
+  // Socket Type : RAW
+  // Protocol : CAN_RAW
+  if ((socket_ = socket(PF_CAN, SOCK_RAW, CAN_RAW)) < 0) {
+    RCLCPP_ERROR(LOGGER, "Failed to generate socket.");
+    return false;
+  }
+
+  // Interface Request
+  struct ifreq ifr;
+  snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "can0");
+  if (ioctl(socket_, SIOCGIFINDEX, &ifr) < 0) {
+    RCLCPP_ERROR(LOGGER, "Failed to io control for interface request.");
+    return false;
+  }
+
+  struct sockaddr_can addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+
+  // アドレスの割当
+  if (bind(socket_, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    RCLCPP_ERROR(LOGGER, "Failed to bind an address to the socket.");
+    return false;
+  }
+
+  return true;
+}
+
+bool WheelController::device_close()
+{
+  if (close(socket_) < 0) {
+    RCLCPP_ERROR(LOGGER, "Failed to close socket.");
+    return false;
+  }
+  return true;
+}
+
+bool WheelController::set_wheel_velocities(
+  const double vel_front_right, const double vel_front_left, const double vel_back_center)
+{
+  constexpr double GEAR_RAITO = 3.6;  // この数値はモタドラと帳尻を合わせること
+  constexpr double LSB = 10;  // 送信データの1bitが、モータ速度の10倍を表す
+  constexpr double WHEEL_TO_MOTOR = GEAR_RAITO * LSB;
+
+  int16_t motor_vel_right = vel_front_right * WHEEL_TO_MOTOR;
+  int16_t motor_vel_left = vel_front_left * WHEEL_TO_MOTOR;
+  int16_t motor_vel_center = vel_back_center * WHEEL_TO_MOTOR;
+
+
+  struct can_frame frame;
+  frame.can_id = 0x1aa;
+  frame.can_dlc = 8;
+  frame.data[0] = 0xFF & motor_vel_right;
+  frame.data[1] = 0xFF & (motor_vel_right >> 8);
+  frame.data[2] = 0xFF & motor_vel_left;
+  frame.data[3] = 0xFF & (motor_vel_left >> 8);
+  frame.data[4] = 0xFF & motor_vel_center;
+  frame.data[5] = 0xFF & (motor_vel_center >> 8);
+  frame.data[6] = 0xFF & motor_vel_right;
+  frame.data[7] = 0xFF & (motor_vel_right >> 8);
+
+  if (write(socket_, &frame, sizeof(struct can_frame)) != sizeof(struct can_frame)) {
+    RCLCPP_ERROR(LOGGER, "Failed to write.");
+    return false;
+  }
+
+  return true;
+}

--- a/frootspi_hardware/src/wheel_controller.cpp
+++ b/frootspi_hardware/src/wheel_controller.cpp
@@ -84,7 +84,7 @@ bool WheelController::device_close()
 bool WheelController::set_wheel_velocities(
   const double vel_front_right, const double vel_front_left, const double vel_back_center)
 {
-  constexpr double GEAR_RAITO = 3.6;  // この数値はモタドラと帳尻を合わせること
+  constexpr double GEAR_RAITO = 2.2/1.091;  // この数値はモタドラと帳尻を合わせること
   constexpr double LSB = 10;  // 送信データの1bitが、モータ速度の10倍を表す
   constexpr double WHEEL_TO_MOTOR = GEAR_RAITO * LSB;
 


### PR DESCRIPTION

hardware_driverに`target_velocities`トピックをパブリッシュするとホイールを回転させます。

また、launchファイルでpigpiodを起動するように変更します。

## テスト方法

1. 最新のGPIO設定スクリプト（https://github.com/SSL-Roots/init_frootspi_gpio_script ）を実行してください。
    - ラズパイ起動時にSPI0をcan0として設定します
2. `$ ros2 launch frootspi_examples hardware.launch.py` でノードを起動します
    - このとき、`pigpiod`と`can0`のソケットも起動します。（`$ sudo pigpiod`を実行しなくてよくなります）
3. ターミナルから`ros2 topic pub /target_wheel_velocities frootspi_msgs/msg/WheelVelocities "{front_right: 0, back_center: 3.14, front_left: 0}"` を実行し、ホイールを回します。
    - `3.14 rad/sec` を指示したとき、ホイールが1秒で1回転すればOKです。

## 懸念点

ギア比の正解が不明なので、3.14 rad/secを指示したときに、だいたい1回転/秒 になる値を設定しています。
