### PR TITLE
frootspi_conductorの追加

### DIFF
--- a/frootspi_conductor/CMakeLists.txt
+++ b/frootspi_conductor/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(consai_frootspi_msgs REQUIRED)
 find_package(frootspi_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -30,6 +31,7 @@ add_library(conductor_component SHARED
 target_compile_definitions(conductor_component
   PRIVATE "FROOTSPI_CONDUCTOR_BUILDING_DLL")
 ament_target_dependencies(conductor_component
+  consai_frootspi_msgs
   frootspi_msgs
   rclcpp
   rclcpp_components
@@ -40,6 +42,7 @@ rclcpp_components_register_nodes(conductor_component "frootspi_conductor::Conduc
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
+ament_export_dependencies(consai_frootspi_msgs)
 ament_export_dependencies(frootspi_msgs)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rclcpp_components)

--- a/frootspi_conductor/CMakeLists.txt
+++ b/frootspi_conductor/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(consai_frootspi_msgs REQUIRED)
 find_package(frootspi_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
 include_directories(include)
@@ -35,7 +34,6 @@ ament_target_dependencies(conductor_component
   frootspi_msgs
   rclcpp
   rclcpp_components
-  rclcpp_lifecycle
   geometry_msgs
 )
 rclcpp_components_register_nodes(conductor_component "frootspi_conductor::Conductor")
@@ -46,7 +44,6 @@ ament_export_dependencies(consai_frootspi_msgs)
 ament_export_dependencies(frootspi_msgs)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rclcpp_components)
-ament_export_dependencies(rclcpp_lifecycle)
 
 ament_export_include_directories(include)
 ament_export_libraries(conductor_component)

--- a/frootspi_conductor/CMakeLists.txt
+++ b/frootspi_conductor/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(frootspi_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(geometry_msgs REQUIRED)
 
 include_directories(include)
 
@@ -33,6 +34,7 @@ ament_target_dependencies(conductor_component
   rclcpp
   rclcpp_components
   rclcpp_lifecycle
+  geometry_msgs
 )
 rclcpp_components_register_nodes(conductor_component "frootspi_conductor::Conductor")
 

--- a/frootspi_conductor/CMakeLists.txt
+++ b/frootspi_conductor/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.5)
+project(frootspi_conductor)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(frootspi_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+
+include_directories(include)
+
+add_library(conductor_component SHARED
+  src/conductor_component.cpp)
+target_compile_definitions(conductor_component
+  PRIVATE "FROOTSPI_CONDUCTOR_BUILDING_DLL")
+ament_target_dependencies(conductor_component
+  frootspi_msgs
+  rclcpp
+  rclcpp_components
+  rclcpp_lifecycle
+)
+rclcpp_components_register_nodes(conductor_component "frootspi_conductor::Conductor")
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+ament_export_dependencies(frootspi_msgs)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(rclcpp_components)
+ament_export_dependencies(rclcpp_lifecycle)
+
+ament_export_include_directories(include)
+ament_export_libraries(conductor_component)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(TARGETS
+  conductor_component
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -36,7 +36,7 @@ namespace frootspi_conductor
 
 using RobotCommand = consai_frootspi_msgs::msg::RobotCommand;
 
-class Conductor : public rclcpp_lifecycle::LifecycleNode
+class Conductor : public rclcpp::Node
 {
 public:
   FROOTSPI_CONDUCTOR_PUBLIC
@@ -45,27 +45,11 @@ public:
 private:
   void callback_commands(const RobotCommand::SharedPtr msg);
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State &);
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_activate(const rclcpp_lifecycle::State &);
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_deactivate(const rclcpp_lifecycle::State &);
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_cleanup(const rclcpp_lifecycle::State &);
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_shutdown(const rclcpp_lifecycle::State &);
-
-  std::shared_ptr<rclcpp::Subscription<RobotCommand>>
-  sub_command_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>>
-  pub_target_velocity_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::DribblePower>>
-  pub_dribble_power_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float32>>
-  pub_kick_power_;
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int16>>
-  pub_kick_flag_;
+  rclcpp::Subscription<RobotCommand>::SharedPtr sub_command_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr pub_target_velocity_;
+  rclcpp::Publisher<frootspi_msgs::msg::DribblePower>::SharedPtr pub_dribble_power_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_kick_power_;
+  rclcpp::Publisher<std_msgs::msg::Int16>::SharedPtr pub_kick_flag_;
 
   int kick_command_;
 };

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -1,0 +1,61 @@
+// Copyright 2021 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FROOTSPI_CONDUCTOR__CONDUCTOR_COMPONENT_HPP_
+#define FROOTSPI_CONDUCTOR__CONDUCTOR_COMPONENT_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "frootspi_conductor/visibility_control.h"
+#include "frootspi_msgs/msg/froots_pi_commands.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+namespace frootspi_conductor
+{
+
+class Conductor : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  FROOTSPI_CONDUCTOR_PUBLIC
+  explicit Conductor(const rclcpp::NodeOptions & options);
+
+private:
+  void callback_commands(const frootspi_msgs::msg::FrootsPiCommands::SharedPtr msg);
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State &);
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_shutdown(const rclcpp_lifecycle::State &);
+
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::FrootsPiCommand>>
+  pub_command_;
+  std::shared_ptr<rclcpp::Subscription<frootspi_msgs::msg::FrootsPiCommands>>
+  sub_frootspi_commands_;
+
+  int my_id_;
+};
+
+}  // namespace frootspi_conductor
+
+#endif  // FROOTSPI_CONDUCTOR__CONDUCTOR_COMPONENT_HPP_

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -28,6 +28,7 @@
 #include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/int16.hpp"
 #include "frootspi_msgs/msg/dribble_power.hpp"
+#include "geometry_msgs/msg/twist.hpp"
 
 namespace frootspi_conductor
 {
@@ -56,6 +57,9 @@ private:
   pub_command_;
   std::shared_ptr<rclcpp::Subscription<frootspi_msgs::msg::FrootsPiCommands>>
   sub_frootspi_commands_;
+
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>>
+  pub_target_velocity_;
 
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::DribblePower>>
   pub_dribble_power_;

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -25,6 +25,9 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
+#include "std_msgs/msg/float32.hpp"
+#include "frootspi_msgs/msg/dribble_power.hpp"
+
 namespace frootspi_conductor
 {
 
@@ -53,7 +56,11 @@ private:
   std::shared_ptr<rclcpp::Subscription<frootspi_msgs::msg::FrootsPiCommands>>
   sub_frootspi_commands_;
 
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::DribblePower>>
+  pub_dribble_power_;
+
   int my_id_;
+  float power_;
 };
 
 }  // namespace frootspi_conductor

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -58,9 +58,10 @@ private:
 
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::DribblePower>>
   pub_dribble_power_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float32>>
+  pub_kick_power_;
 
   int my_id_;
-  float power_;
 };
 
 }  // namespace frootspi_conductor

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -26,6 +26,7 @@
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
 #include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/int16.hpp"
 #include "frootspi_msgs/msg/dribble_power.hpp"
 
 namespace frootspi_conductor
@@ -60,8 +61,11 @@ private:
   pub_dribble_power_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float32>>
   pub_kick_power_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int16>>
+  pub_kick_flag_;
 
   int my_id_;
+  int kick_command_;
 };
 
 }  // namespace frootspi_conductor

--- a/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
+++ b/frootspi_conductor/include/frootspi_conductor/conductor_component.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "consai_frootspi_msgs/msg/robot_command.hpp"
 #include "frootspi_conductor/visibility_control.h"
 #include "frootspi_msgs/msg/froots_pi_commands.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -33,6 +34,8 @@
 namespace frootspi_conductor
 {
 
+using RobotCommand = consai_frootspi_msgs::msg::RobotCommand;
+
 class Conductor : public rclcpp_lifecycle::LifecycleNode
 {
 public:
@@ -40,7 +43,7 @@ public:
   explicit Conductor(const rclcpp::NodeOptions & options);
 
 private:
-  void callback_commands(const frootspi_msgs::msg::FrootsPiCommands::SharedPtr msg);
+  void callback_commands(const RobotCommand::SharedPtr msg);
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State &);
@@ -53,14 +56,10 @@ private:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_shutdown(const rclcpp_lifecycle::State &);
 
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::FrootsPiCommand>>
-  pub_command_;
-  std::shared_ptr<rclcpp::Subscription<frootspi_msgs::msg::FrootsPiCommands>>
-  sub_frootspi_commands_;
-
+  std::shared_ptr<rclcpp::Subscription<RobotCommand>>
+  sub_command_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>>
   pub_target_velocity_;
-
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<frootspi_msgs::msg::DribblePower>>
   pub_dribble_power_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float32>>
@@ -68,7 +67,6 @@ private:
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int16>>
   pub_kick_flag_;
 
-  int my_id_;
   int kick_command_;
 };
 

--- a/frootspi_conductor/include/frootspi_conductor/visibility_control.h
+++ b/frootspi_conductor/include/frootspi_conductor/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2021 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FROOTSPI_CONDUCTOR__VISIBILITY_CONTROL_H_
+#define FROOTSPI_CONDUCTOR__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define FROOTSPI_CONDUCTOR_EXPORT __attribute__ ((dllexport))
+    #define FROOTSPI_CONDUCTOR_IMPORT __attribute__ ((dllimport))
+  #else
+    #define FROOTSPI_CONDUCTOR_EXPORT __declspec(dllexport)
+    #define FROOTSPI_CONDUCTOR_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef FROOTSPI_CONDUCTOR_BUILDING_DLL
+    #define FROOTSPI_CONDUCTOR_PUBLIC FROOTSPI_CONDUCTOR_EXPORT
+  #else
+    #define FROOTSPI_CONDUCTOR_PUBLIC FROOTSPI_CONDUCTOR_IMPORT
+  #endif
+  #define FROOTSPI_CONDUCTOR_PUBLIC_TYPE FROOTSPI_CONDUCTOR_PUBLIC
+  #define FROOTSPI_CONDUCTOR_LOCAL
+#else
+  #define FROOTSPI_CONDUCTOR_EXPORT __attribute__ ((visibility("default")))
+  #define FROOTSPI_CONDUCTOR_IMPORT
+  #if __GNUC__ >= 4
+    #define FROOTSPI_CONDUCTOR_PUBLIC __attribute__ ((visibility("default")))
+    #define FROOTSPI_CONDUCTOR_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define FROOTSPI_CONDUCTOR_PUBLIC
+    #define FROOTSPI_CONDUCTOR_LOCAL
+  #endif
+  #define FROOTSPI_CONDUCTOR_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // FROOTSPI_CONDUCTOR__VISIBILITY_CONTROL_H_

--- a/frootspi_conductor/package.xml
+++ b/frootspi_conductor/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>frootspi_conductor</name>
+  <version>0.1.0</version>
+  <description>FrootsPi conductor package.</description>
+  <maintainer email="macakasit@gmail.com">ubuntu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>frootspi_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/frootspi_conductor/package.xml
+++ b/frootspi_conductor/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>consai_frootspi_msgs</depend>
   <depend>frootspi_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/frootspi_conductor/package.xml
+++ b/frootspi_conductor/package.xml
@@ -13,7 +13,6 @@
   <depend>frootspi_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>rclcpp_lifecycle</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -48,19 +48,23 @@ void Conductor::callback_commands(const frootspi_msgs::msg::FrootsPiCommands::Sh
 
   for(auto command : msg->commands){
     if(command.robot_id == my_id_){
-      power_ = command.dribble_power;
-      std::cout<<"ドリブルパワーは"<<std::to_string(power_)<<"です"<<std::endl;
+      std::cout<<"ドリブルパワーは"<<std::to_string(command.dribble_power)<<"です"<<std::endl;
+      std::cout<<"キックパワーは"<<std::to_string(command.kick_power)<<"です"<<std::endl;
+
+      // publish
+      auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
+      dribble_power->power = command.dribble_power;
+      pub_dribble_power_->publish(std::move(dribble_power));
+      auto kick_power = std::make_unique<std_msgs::msg::Float32>();
+      kick_power->data = command.kick_power;
+      pub_kick_power_->publish(std::move(kick_power));
+
       break;
     }
   }
 
   std::cout<<"処理を終えます。"<<std::endl;
   std::cout<<"----------------------"<<std::endl;
-
-  // publish
-  auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
-  dribble_power->power = power_;
-  pub_dribble_power_->publish(std::move(dribble_power));
 
 }
 
@@ -78,6 +82,7 @@ CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
 
   pub_command_ = create_publisher<frootspi_msgs::msg::FrootsPiCommand>("command", 1);
   pub_dribble_power_ = create_publisher<frootspi_msgs::msg::DribblePower>("dribble_power", 1);
+  pub_kick_power_ = create_publisher<std_msgs::msg::Float32>("kick_power", 1);
 
   return CallbackReturn::SUCCESS;
 }
@@ -88,6 +93,7 @@ CallbackReturn Conductor::on_activate(const rclcpp_lifecycle::State &)
 
   pub_command_->on_activate();
   pub_dribble_power_->on_activate();
+  pub_kick_power_->on_activate();
 
   return CallbackReturn::SUCCESS;
 }
@@ -98,6 +104,7 @@ CallbackReturn Conductor::on_deactivate(const rclcpp_lifecycle::State &)
 
   pub_command_->on_deactivate();
   pub_dribble_power_->on_deactivate();
+  pub_kick_power_->on_deactivate();
 
   return CallbackReturn::SUCCESS;
 }
@@ -108,6 +115,7 @@ CallbackReturn Conductor::on_cleanup(const rclcpp_lifecycle::State &)
 
   pub_command_.reset();
   pub_dribble_power_.reset();
+  pub_kick_power_.reset();
 
   return CallbackReturn::SUCCESS;
 }
@@ -118,6 +126,7 @@ CallbackReturn Conductor::on_shutdown(const rclcpp_lifecycle::State &)
 
   pub_command_.reset();
   pub_dribble_power_.reset();
+  pub_kick_power_.reset();
 
   return CallbackReturn::SUCCESS;
 }

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -1,0 +1,110 @@
+// Copyright 2021 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "frootspi_conductor/conductor_component.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+namespace frootspi_conductor
+{
+
+Conductor::Conductor(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("frootspi_conductor", options),
+  my_id_(-1)
+{
+}
+
+void Conductor::callback_commands(const frootspi_msgs::msg::FrootsPiCommands::SharedPtr msg)
+{
+  std::cout<<"FrootsPiCommandsを受け取りました。"<<std::endl;
+  std::cout<<"私のIDは"<<std::to_string(my_id_)<<"です"<<std::endl;
+
+  if(msg->is_yellow){
+    std::cout<<"チームカラーは黄色です"<<std::endl;
+  }else{
+    std::cout<<"チームカラーは青色です"<<std::endl;
+  }
+
+  for(auto command : msg->commands){
+    std::cout<<"ロボットIDは"<<std::to_string(command.robot_id)<<"です"<<std::endl;
+  }
+
+  std::cout<<"処理を終えます。"<<std::endl;
+  std::cout<<"----------------------"<<std::endl;
+}
+
+CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
+{
+  using namespace std::placeholders;  // for _1, _2, _3...
+
+  RCLCPP_INFO(this->get_logger(), "on_configure() is called.");
+
+  sub_frootspi_commands_ = create_subscription<frootspi_msgs::msg::FrootsPiCommands>(
+    "frootspi_commands", 1, std::bind(&Conductor::callback_commands, this, _1));
+
+  declare_parameter("my_id", -1);
+  my_id_ = get_parameter("my_id").get_value<int>();
+
+  pub_command_ = create_publisher<frootspi_msgs::msg::FrootsPiCommand>("command", 1);
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn Conductor::on_activate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_activate() is called.");
+
+  pub_command_->on_activate();
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn Conductor::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_deactivate() is called.");
+
+  pub_command_->on_deactivate();
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn Conductor::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_cleanup() is called.");
+
+  pub_command_.reset();
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn Conductor::on_shutdown(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(this->get_logger(), "on_shutdown() is called.");
+
+  pub_command_.reset();
+
+  return CallbackReturn::SUCCESS;
+}
+
+}  // namespace frootspi_conductor
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(frootspi_conductor::Conductor)

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -51,12 +51,19 @@ void Conductor::callback_commands(const frootspi_msgs::msg::FrootsPiCommands::Sh
       std::cout<<"ドリブルパワーは"<<std::to_string(command.dribble_power)<<"です"<<std::endl;
       std::cout<<"キックパワーは"<<std::to_string(command.kick_power)<<"です"<<std::endl;
 
+      // キックフラグの定義, 現状チップキックかどうかだけ
+      // 0: 未定, 1: ストレート, 2: チップ, 3: 放電
+      kick_command_ = command.chip_enable + 1;
+
       // publish
       auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
       dribble_power->power = command.dribble_power;
       pub_dribble_power_->publish(std::move(dribble_power));
       auto kick_power = std::make_unique<std_msgs::msg::Float32>();
       kick_power->data = command.kick_power;
+      pub_kick_power_->publish(std::move(kick_power));
+      auto kick_flag = std::make_unique<std_msgs::msg::Int16>();
+      kick_flag->data = kick_command_;
       pub_kick_power_->publish(std::move(kick_power));
 
       break;
@@ -83,6 +90,7 @@ CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
   pub_command_ = create_publisher<frootspi_msgs::msg::FrootsPiCommand>("command", 1);
   pub_dribble_power_ = create_publisher<frootspi_msgs::msg::DribblePower>("dribble_power", 1);
   pub_kick_power_ = create_publisher<std_msgs::msg::Float32>("kick_power", 1);
+  pub_kick_flag_ = create_publisher<std_msgs::msg::Int16>("kick_flag", 1);
 
   return CallbackReturn::SUCCESS;
 }
@@ -94,6 +102,7 @@ CallbackReturn Conductor::on_activate(const rclcpp_lifecycle::State &)
   pub_command_->on_activate();
   pub_dribble_power_->on_activate();
   pub_kick_power_->on_activate();
+  pub_kick_flag_->on_activate();
 
   return CallbackReturn::SUCCESS;
 }
@@ -105,6 +114,7 @@ CallbackReturn Conductor::on_deactivate(const rclcpp_lifecycle::State &)
   pub_command_->on_deactivate();
   pub_dribble_power_->on_deactivate();
   pub_kick_power_->on_deactivate();
+  pub_kick_flag_->on_deactivate();
 
   return CallbackReturn::SUCCESS;
 }
@@ -116,6 +126,7 @@ CallbackReturn Conductor::on_cleanup(const rclcpp_lifecycle::State &)
   pub_command_.reset();
   pub_dribble_power_.reset();
   pub_kick_power_.reset();
+  pub_kick_flag_.reset();
 
   return CallbackReturn::SUCCESS;
 }
@@ -127,6 +138,7 @@ CallbackReturn Conductor::on_shutdown(const rclcpp_lifecycle::State &)
   pub_command_.reset();
   pub_dribble_power_.reset();
   pub_kick_power_.reset();
+  pub_kick_flag_.reset();
 
   return CallbackReturn::SUCCESS;
 }

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -24,7 +25,8 @@ namespace frootspi_conductor
 {
 
 Conductor::Conductor(const rclcpp::NodeOptions & options)
-: Node("frootspi_conductor", options) {
+: Node("frootspi_conductor", options)
+{
   using namespace std::placeholders;  // for _1, _2, _3...
 
   sub_command_ = create_subscription<RobotCommand>(

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -26,46 +26,41 @@ namespace frootspi_conductor
 {
 
 Conductor::Conductor(const rclcpp::NodeOptions & options)
-: rclcpp_lifecycle::LifecycleNode("frootspi_conductor", options),
-  my_id_(-1)
-{
+: rclcpp_lifecycle::LifecycleNode("frootspi_conductor", options) {
 }
 
-void Conductor::callback_commands(const frootspi_msgs::msg::FrootsPiCommands::SharedPtr msg)
+void Conductor::callback_commands(const RobotCommand::SharedPtr msg)
 {
-  // コマンドの有無を判定
-  for(auto command : msg->commands){
-    // 自身のIDと一致しているか判定
-    if(command.robot_id == my_id_){
-      // publish
-      // 速度
-      auto target_velocity = std::make_unique<geometry_msgs::msg::Twist>();
-      target_velocity->linear.x = command.vel_x;
-      target_velocity->linear.y = command.vel_y;
-      target_velocity->angular.z = command.vel_angular;
-      pub_target_velocity_->publish(std::move(target_velocity));
+  // RobotCommandをFrootsPiの各ハードウェア向けのトピックに分解してPublishする
+  // 速度
+  auto target_velocity = std::make_unique<geometry_msgs::msg::Twist>();
+  target_velocity->linear.x = msg->velocity_x;
+  target_velocity->linear.y = msg->velocity_y;
+  target_velocity->angular.z = msg->velocity_theta;
+  pub_target_velocity_->publish(std::move(target_velocity));
 
-      // ドリブルパワー
-      auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
-      dribble_power->power = command.dribble_power;
-      pub_dribble_power_->publish(std::move(dribble_power));
+  // キックパワーが0より大きいとき、kick_powerとkick_flagをpublishする
+  if (msg->kick_power > 0.0) {
+    auto kick_power = std::make_unique<std_msgs::msg::Float32>();
+    kick_power->data = msg->kick_power;
+    pub_kick_power_->publish(std::move(kick_power));
 
-      // キックパワー
-      auto kick_power = std::make_unique<std_msgs::msg::Float32>();
-      kick_power->data = command.kick_power;
-      pub_kick_power_->publish(std::move(kick_power));
-
-      // キックフラグ
-      auto kick_flag = std::make_unique<std_msgs::msg::Int16>();
-      // 現状はチップキックかどうかだけ実装
-      // 0: 未定, 1: ストレート, 2: チップ, 3: 放電
-      kick_flag->data = (int)(command.chip_enable) + 1;
-      pub_kick_flag_->publish(std::move(kick_flag));
-
-      break;
+    // キックフラグ
+    auto kick_flag = std::make_unique<std_msgs::msg::Int16>();
+    // 現状はチップキックかどうかだけ実装
+    // 0: 未定, 1: ストレート, 2: チップ, 3: 放電
+    if (msg->chip_kick) {
+      kick_flag->data = 2;
+    } else {
+      kick_flag->data = 1;
     }
+    pub_kick_flag_->publish(std::move(kick_flag));
   }
 
+  // ドリブルパワー
+  auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
+  dribble_power->power = msg->dribble_power;
+  pub_dribble_power_->publish(std::move(dribble_power));
 }
 
 CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
@@ -74,11 +69,8 @@ CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
 
   RCLCPP_INFO(this->get_logger(), "on_configure() is called.");
 
-  sub_frootspi_commands_ = create_subscription<frootspi_msgs::msg::FrootsPiCommands>(
-    "frootspi_commands", 1, std::bind(&Conductor::callback_commands, this, _1));
-
-  declare_parameter("my_id", -1);
-  my_id_ = get_parameter("my_id").get_value<int>();
+  sub_command_ = create_subscription<RobotCommand>(
+    "command", 1, std::bind(&Conductor::callback_commands, this, _1));
 
   pub_target_velocity_ = create_publisher<geometry_msgs::msg::Twist>("target_velocity", 1);
   pub_dribble_power_ = create_publisher<frootspi_msgs::msg::DribblePower>("dribble_power", 1);

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -33,45 +33,38 @@ Conductor::Conductor(const rclcpp::NodeOptions & options)
 
 void Conductor::callback_commands(const frootspi_msgs::msg::FrootsPiCommands::SharedPtr msg)
 {
-  std::cout<<"FrootsPiCommandsを受け取りました。"<<std::endl;
-  std::cout<<"私のIDは"<<std::to_string(my_id_)<<"です"<<std::endl;
-
-  if(msg->is_yellow){
-    std::cout<<"チームカラーは黄色です"<<std::endl;
-  }else{
-    std::cout<<"チームカラーは青色です"<<std::endl;
-  }
-
+  // コマンドの有無を判定
   for(auto command : msg->commands){
-    std::cout<<"ロボットIDは"<<std::to_string(command.robot_id)<<"です"<<std::endl;
-  }
-
-  for(auto command : msg->commands){
+    // 自身のIDと一致しているか判定
     if(command.robot_id == my_id_){
-      std::cout<<"ドリブルパワーは"<<std::to_string(command.dribble_power)<<"です"<<std::endl;
-      std::cout<<"キックパワーは"<<std::to_string(command.kick_power)<<"です"<<std::endl;
-
-      // キックフラグの定義, 現状チップキックかどうかだけ
-      // 0: 未定, 1: ストレート, 2: チップ, 3: 放電
-      kick_command_ = command.chip_enable + 1;
-
       // publish
+      // 速度
+      auto target_velocity = std::make_unique<geometry_msgs::msg::Twist>();
+      target_velocity->linear.x = command.vel_x;
+      target_velocity->linear.y = command.vel_y;
+      target_velocity->angular.z = command.vel_angular;
+      pub_target_velocity_->publish(std::move(target_velocity));
+
+      // ドリブルパワー
       auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
       dribble_power->power = command.dribble_power;
       pub_dribble_power_->publish(std::move(dribble_power));
+
+      // キックパワー
       auto kick_power = std::make_unique<std_msgs::msg::Float32>();
       kick_power->data = command.kick_power;
       pub_kick_power_->publish(std::move(kick_power));
+
+      // キックフラグ
       auto kick_flag = std::make_unique<std_msgs::msg::Int16>();
-      kick_flag->data = kick_command_;
-      pub_kick_power_->publish(std::move(kick_power));
+      // 現状はチップキックかどうかだけ実装
+      // 0: 未定, 1: ストレート, 2: チップ, 3: 放電
+      kick_flag->data = (int)(command.chip_enable) + 1;
+      pub_kick_flag_->publish(std::move(kick_flag));
 
       break;
     }
   }
-
-  std::cout<<"処理を終えます。"<<std::endl;
-  std::cout<<"----------------------"<<std::endl;
 
 }
 
@@ -87,7 +80,7 @@ CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
   declare_parameter("my_id", -1);
   my_id_ = get_parameter("my_id").get_value<int>();
 
-  pub_command_ = create_publisher<frootspi_msgs::msg::FrootsPiCommand>("command", 1);
+  pub_target_velocity_ = create_publisher<geometry_msgs::msg::Twist>("target_velocity", 1);
   pub_dribble_power_ = create_publisher<frootspi_msgs::msg::DribblePower>("dribble_power", 1);
   pub_kick_power_ = create_publisher<std_msgs::msg::Float32>("kick_power", 1);
   pub_kick_flag_ = create_publisher<std_msgs::msg::Int16>("kick_flag", 1);
@@ -99,7 +92,7 @@ CallbackReturn Conductor::on_activate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_activate() is called.");
 
-  pub_command_->on_activate();
+  pub_target_velocity_->on_activate();
   pub_dribble_power_->on_activate();
   pub_kick_power_->on_activate();
   pub_kick_flag_->on_activate();
@@ -111,7 +104,7 @@ CallbackReturn Conductor::on_deactivate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_deactivate() is called.");
 
-  pub_command_->on_deactivate();
+  pub_target_velocity_->on_deactivate();
   pub_dribble_power_->on_deactivate();
   pub_kick_power_->on_deactivate();
   pub_kick_flag_->on_deactivate();
@@ -123,7 +116,7 @@ CallbackReturn Conductor::on_cleanup(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_cleanup() is called.");
 
-  pub_command_.reset();
+  // pub_target_velocity_->reset();
   pub_dribble_power_.reset();
   pub_kick_power_.reset();
   pub_kick_flag_.reset();
@@ -135,7 +128,7 @@ CallbackReturn Conductor::on_shutdown(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(this->get_logger(), "on_shutdown() is called.");
 
-  pub_command_.reset();
+  // pub_target_velocity_->reset();
   pub_dribble_power_.reset();
   pub_kick_power_.reset();
   pub_kick_flag_.reset();

--- a/frootspi_conductor/src/conductor_component.cpp
+++ b/frootspi_conductor/src/conductor_component.cpp
@@ -46,8 +46,22 @@ void Conductor::callback_commands(const frootspi_msgs::msg::FrootsPiCommands::Sh
     std::cout<<"ロボットIDは"<<std::to_string(command.robot_id)<<"です"<<std::endl;
   }
 
+  for(auto command : msg->commands){
+    if(command.robot_id == my_id_){
+      power_ = command.dribble_power;
+      std::cout<<"ドリブルパワーは"<<std::to_string(power_)<<"です"<<std::endl;
+      break;
+    }
+  }
+
   std::cout<<"処理を終えます。"<<std::endl;
   std::cout<<"----------------------"<<std::endl;
+
+  // publish
+  auto dribble_power = std::make_unique<frootspi_msgs::msg::DribblePower>();
+  dribble_power->power = power_;
+  pub_dribble_power_->publish(std::move(dribble_power));
+
 }
 
 CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
@@ -63,6 +77,7 @@ CallbackReturn Conductor::on_configure(const rclcpp_lifecycle::State &)
   my_id_ = get_parameter("my_id").get_value<int>();
 
   pub_command_ = create_publisher<frootspi_msgs::msg::FrootsPiCommand>("command", 1);
+  pub_dribble_power_ = create_publisher<frootspi_msgs::msg::DribblePower>("dribble_power", 1);
 
   return CallbackReturn::SUCCESS;
 }
@@ -72,6 +87,7 @@ CallbackReturn Conductor::on_activate(const rclcpp_lifecycle::State &)
   RCLCPP_INFO(this->get_logger(), "on_activate() is called.");
 
   pub_command_->on_activate();
+  pub_dribble_power_->on_activate();
 
   return CallbackReturn::SUCCESS;
 }
@@ -81,6 +97,7 @@ CallbackReturn Conductor::on_deactivate(const rclcpp_lifecycle::State &)
   RCLCPP_INFO(this->get_logger(), "on_deactivate() is called.");
 
   pub_command_->on_deactivate();
+  pub_dribble_power_->on_deactivate();
 
   return CallbackReturn::SUCCESS;
 }
@@ -90,6 +107,7 @@ CallbackReturn Conductor::on_cleanup(const rclcpp_lifecycle::State &)
   RCLCPP_INFO(this->get_logger(), "on_cleanup() is called.");
 
   pub_command_.reset();
+  pub_dribble_power_.reset();
 
   return CallbackReturn::SUCCESS;
 }
@@ -99,6 +117,7 @@ CallbackReturn Conductor::on_shutdown(const rclcpp_lifecycle::State &)
   RCLCPP_INFO(this->get_logger(), "on_shutdown() is called.");
 
   pub_command_.reset();
+  pub_dribble_power_.reset();
 
   return CallbackReturn::SUCCESS;
 }

--- a/frootspi_examples/launch/conductor.launch.py
+++ b/frootspi_examples/launch/conductor.launch.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.event_handlers import OnProcessStart
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def generate_launch_description():
+    container = ComposableNodeContainer(
+        name='frootspi_container',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',  # component_container_mtはmulti threads
+        composable_node_descriptions=[
+            ComposableNode(
+                package='frootspi_conductor',
+                plugin='frootspi_conductor::Conductor',
+                name='frootspi_conductor',
+                parameters=[{'my_id': 0}],
+                extra_arguments=[{'use_intra_process_comms': True}],
+                ),
+        ],
+        output='screen',
+    )
+
+    configure_conductor_node = ExecuteProcess(
+        cmd=['ros2 lifecycle set frootspi_conductor configure'],
+        shell=True,
+        output='screen',
+    )
+
+    activate_conductor_node = ExecuteProcess(
+        cmd=['ros2 lifecycle set frootspi_conductor activate'],
+        shell=True,
+        output='screen',
+    )
+
+    return LaunchDescription([
+        RegisterEventHandler(
+            event_handler=OnProcessStart(
+                target_action=container,
+                on_start=[configure_conductor_node],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=configure_conductor_node,
+                on_exit=[activate_conductor_node],
+            )
+        ),
+        container
+        ])

--- a/frootspi_examples/launch/conductor.launch.py
+++ b/frootspi_examples/launch/conductor.launch.py
@@ -14,10 +14,6 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import ExecuteProcess
-from launch.actions import RegisterEventHandler
-from launch.event_handlers import OnProcessExit
-from launch.event_handlers import OnProcessStart
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
@@ -50,31 +46,7 @@ def generate_launch_description():
         output='screen',
     )
 
-    configure_conductor_node = ExecuteProcess(
-        cmd=['ros2 lifecycle set ' + namespace_str + '/' + node_name + ' configure'],
-        shell=True,
-        output='screen',
-    )
-
-    activate_conductor_node = ExecuteProcess(
-        cmd=['ros2 lifecycle set ' + namespace_str + '/' + node_name + ' activate'],
-        shell=True,
-        output='screen',
-    )
-
     return LaunchDescription([
         declare_arg_robot_id,
-        RegisterEventHandler(
-            event_handler=OnProcessStart(
-                target_action=container,
-                on_start=[configure_conductor_node],
-            )
-        ),
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=configure_conductor_node,
-                on_exit=[activate_conductor_node],
-            )
-        ),
         container
         ])

--- a/frootspi_examples/launch/conductor.launch.py
+++ b/frootspi_examples/launch/conductor.launch.py
@@ -16,6 +16,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import PushRosNamespace
 from launch_ros.descriptions import ComposableNode
 
 
@@ -24,11 +25,9 @@ def generate_launch_description():
         'robot_id', default_value='0',
         description=('Set own ID.')
     )
+    push_ns = PushRosNamespace(['robot', LaunchConfiguration('robot_id')])
 
     # robot_id = LaunchConfiguration('robot_id')
-    robot_id = 0
-    namespace_str = 'robot' + str(robot_id)
-    node_name = 'frootspi_conductor'
     container = ComposableNodeContainer(
         name='frootspi_container',
         namespace='',
@@ -38,8 +37,7 @@ def generate_launch_description():
             ComposableNode(
                 package='frootspi_conductor',
                 plugin='frootspi_conductor::Conductor',
-                name=node_name,
-                namespace=namespace_str,
+                name='frootspi_conductor',
                 extra_arguments=[{'use_intra_process_comms': True}],
                 ),
         ],
@@ -48,5 +46,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         declare_arg_robot_id,
+        push_ns,
         container
         ])

--- a/frootspi_msgs/CMakeLists.txt
+++ b/frootspi_msgs/CMakeLists.txt
@@ -41,10 +41,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
+# if(BUILD_TESTING)
+#   find_package(ament_lint_auto REQUIRED)
+#   ament_lint_auto_find_test_dependencies()
+# endif()
 
 ament_export_dependencies(rosidl_default_runtime)
 


### PR DESCRIPTION
- 入力
  - IDと速度情報
  - FrootsPiCommandsもらう
- 出力
  - 目標速度：geometry_msgs/Twist
  - geometry_msgs::Twist : target_velocity
- ドリブラー回転：dribble_power
  - frootspi_msgs::DribblePower : dribble_power
- キックパワーkick_power
  - std_msgs::Float32 : kick_power
- キックフラグ：kick_flag
  - 0：未定，1：ストレート，2：チップ，3：放電
  - 現状は1と2だけ実装されている
