### PR TITLE
ロボットの運用に便利なコマンドを追加

### DIFF
--- a/frootspi_examples/utils/discharge_all_robots.sh
+++ b/frootspi_examples/utils/discharge_all_robots.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+ros2 service call /robot0/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot1/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot2/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot3/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot4/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot5/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot6/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot7/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot8/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot9/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot10/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &
+ros2 service call /robot11/kick frootspi_msgs/srv/Kick "{kick_type: 3, kick_power: 1.0}" &

--- a/frootspi_examples/utils/shutdown.sh
+++ b/frootspi_examples/utils/shutdown.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# shutdown.sh
+# IPアドレスを指定して、SSHログインを行いシャットダウンします
+# 一気にシャットダウンしたいときは shutdown_all_robots.sh を使ってください
+#
+# Usage:
+# $ shutdown.sh IP_ADDRESS
+
+SSH_USER=ubuntu
+
+if [ -z "${1}" ]; then
+    echo "IPアドレスを渡してください"
+    exit 1
+fi
+
+IP_ADDR=${1}
+
+echo "=========="
+echo "PING test..."
+
+ping -c 1 -W 1 ${IP_ADDR}
+
+if [ $? -ne 0 ]; then
+    echo "PING Failed."
+    exit 2
+fi
+echo "PING OK!"
+
+echo "=========="
+echo "SSH Connect..."
+ssh ${SSH_USER}@${IP_ADDR} <<EOC
+sudo poweroff
+EOC
+echo "SSH Command completed"
+echo "=========="
+

--- a/frootspi_examples/utils/shutdown_all_robots.sh
+++ b/frootspi_examples/utils/shutdown_all_robots.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# shutdown_all_robots.sh
+# ロボット全台のRaspiをシャットダウンします
+# 
+# Usage:
+# $ ./shutdown_all_robots.sh
+
+cd `dirname $0`
+mkdir -p logs
+
+IP_ADDR_LIST="192.168.0.100 192.168.0.101 192.168.0.102 192.168.0.103 192.168.0.104 192.168.0.105 192.168.0.106 192.168.0.107 192.168.0.108 192.168.0.109 192.168.0.110 192.168.0.111"
+
+DATE=`date '+%Y%m%d%H%M%S'`
+for ip_addr in ${IP_ADDR_LIST}; do
+    ./shutdown.sh ${ip_addr} > logs/shutdown_${ip_addr}_${DATE} &
+done

--- a/frootspi_examples/utils/ssh-copy-id-for-all-robots.sh
+++ b/frootspi_examples/utils/ssh-copy-id-for-all-robots.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# ssh-copy-id-for-all-robots.sh
+#
+# SSH鍵を転送してパスワード無しでSSHできるようにします
+#
+# Usage:
+# $ ssh-copy-id-for-all-robots.sh
+
+SSH_USER=ubuntu
+IP_ADDR_LIST="192.168.0.100 192.168.0.101 192.168.0.102 192.168.0.103 192.168.0.104 192.168.0.105 192.168.0.106 192.168.0.107 192.168.0.108 192.168.0.109 192.168.0.110 192.168.0.111"
+
+for ip_addr in ${IP_ADDR_LIST}; do
+    ssh-copy-id ${SSH_USER}@${ip_addr}
+done


### PR DESCRIPTION
ロボットの運用に便利なコマンドを追加しました。

- 全台にパスワード入力無しでログインできるようにする `ssh-copy-id-for-all-robots.sh `
- 全台を一斉に放電させる `discharge_all_robots.sh `
- 全台を一斉にシャットダウンさせる `shutdown_all_robots.sh`
