### PR TITLE
オフラインでもロボットが起動するよう修正

### DIFF
--- a/frootspi_examples/launch/robot.launch.py
+++ b/frootspi_examples/launch/robot.launch.py
@@ -15,12 +15,10 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
 from launch.actions import ExecuteProcess
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.event_handlers import OnProcessStart
-from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import PushRosNamespace
 from launch_ros.descriptions import ComposableNode

--- a/frootspi_examples/launch/robot.launch.py
+++ b/frootspi_examples/launch/robot.launch.py
@@ -86,12 +86,6 @@ def generate_launch_description():
         output='screen',
     )
 
-    start_pigpiod = ExecuteProcess(
-        cmd=['sudo pigpiod -s 1'],  # サンプリングレートを1usecに変更
-        shell=True,
-        output='screen',
-    )
-
     start_socket_can0 = ExecuteProcess(
         cmd=['sudo ip link set can0 up type can bitrate 1000000'],
         shell=True,
@@ -112,7 +106,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         push_ns,
-        start_pigpiod,
         start_socket_can0,
         RegisterEventHandler(
             event_handler=OnProcessStart(

--- a/frootspi_examples/launch/robot.launch.py
+++ b/frootspi_examples/launch/robot.launch.py
@@ -101,13 +101,13 @@ def generate_launch_description():
     )
 
     configure_hardware_node = ExecuteProcess(
-        cmd=[['sleep 5 && ros2 lifecycle set robot', LaunchConfiguration('id'), '/hardware_driver configure']],
+        cmd=[['sleep 5 && ros2 lifecycle set robot', str(robot_id), '/hardware_driver configure']],
         shell=True,
         output='screen',
     )
 
     activate_hardware_node = ExecuteProcess(
-        cmd=[['ros2 lifecycle set robot', LaunchConfiguration('id'), '/hardware_driver activate']],
+        cmd=[['ros2 lifecycle set robot', str(robot_id), '/hardware_driver activate']],
         shell=True,
         output='screen',
     )

--- a/frootspi_examples/systemd/pigpiod.service
+++ b/frootspi_examples/systemd/pigpiod.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pigpio daemon
+
+[Service]
+Type=forking
+PIDFile=pigpio.pid
+ExecStart=/usr/local/bin/pigpiod
+
+[Install]
+WantedBy=multi-user.target

--- a/frootspi_examples/systemd/register_systemd.sh
+++ b/frootspi_examples/systemd/register_systemd.sh
@@ -2,6 +2,10 @@
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
+sudo ln -s ${SCRIPT_DIR}/pigpiod.service /etc/systemd/system
+sudo systemctl enable pigpiod.service
+sudo systemctl start pigpiod.service
+
 sudo ln -s ${SCRIPT_DIR}/robot_launch.service /etc/systemd/system
 sudo systemctl enable robot_launch.service
 sudo systemctl start robot_launch.service

--- a/frootspi_examples/systemd/robot_launch.service
+++ b/frootspi_examples/systemd/robot_launch.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=ROS2 robot launch
+Require=pigpio.service
 After=local-fs.target
+After=pigpio.service
 ConditionPathExists=/home/ubuntu/ros2_ws/src/FrootsPi/frootspi_examples/systemd
 
 [Service]

--- a/frootspi_examples/systemd/robot_launch.sh
+++ b/frootspi_examples/systemd/robot_launch.sh
@@ -9,15 +9,9 @@ if [ -f ${ENVFILE} ]; then
     source ${ENVFILE}
     export ROS_DOMAIN_ID=${ROS_DOMAIN_ID_VALUE}
 
-    # IPアドレスからロボットIDを取得
-    # IPアドレスの下2ケタがIDと対応している
-    IFACE="wlan0"
-    IP_ADDRESS=$(/sbin/ip -f inet -o addr show "${IFACE}" | cut -d\  -f 7 | cut -d/ -f 1)
-    ROBOT_ID=`echo ${IP_ADDRESS: -2:2} | sed -e 's/^0//g'`
-
     echo "ROS2 Launching..."
     #roslaunch実行
-    exec ros2 launch frootspi_examples robot.launch.py id:=${ROBOT_ID}
+    exec ros2 launch frootspi_examples robot.launch.py
 else
     echo "There is no ${ENVFILE}"
 fi

--- a/frootspi_examples/systemd/robot_launch.sh
+++ b/frootspi_examples/systemd/robot_launch.sh
@@ -11,6 +11,7 @@ if [ -f ${ENVFILE} ]; then
 
     echo "ROS2 Launching..."
     #roslaunch実行
+    sleep 1 # wait for pigpiod
     exec ros2 launch frootspi_examples robot.launch.py
 else
     echo "There is no ${ENVFILE}"


### PR DESCRIPTION
オフラインでもロボットが起動するよう修正を加えました。

- IDを ~/robot_config.yaml から読み込んで設定するように変更しました
  - 以前はIPアドレスの末尾2桁をIDとしていましたが、これだとオフライン状態でロボットが起動しなくなるためやめました
- pigpiodをsystemdで起動するように変更しました
  - robot.launch.py の中で起動するようになっていましたが、起動順序が制御されていなかったため、pigpiod起動前にhardware_driverノードがpigpiodにアクセスしようとして失敗することがたまにありました。
  - systemdを使って起動順を制御するようにしました。
  - （あと、robot.launch.pyをしていないときでもpigpiodは起動していたほうが望ましいと思うので、このように変更しました)