### PR TITLE
ネットワーク再接続時にrobot_launch.serviceをrestartするデーモン frootspi_netwatcherを追加

### DIFF
--- a/frootspi_examples/systemd/frootspi_netwatcher.service
+++ b/frootspi_examples/systemd/frootspi_netwatcher.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Restart FrootsPi robot_launch service when network is reconnected
+Require=robot_launch.service
+After=local-fs.target
+After=robot_launch.service
+ConditionPathExists=/home/ubuntu/ros2_ws/src/FrootsPi/frootspi_examples/systemd
+
+[Service]
+ExecStart=/home/ubuntu/ros2_ws/src/FrootsPi/frootspi_examples/systemd/frootspi_netwatcher.sh
+ExecStop=/bin/kill ${MAINPID}
+Restart=on-failure
+StartLimitInterval=60
+StartLimitBurst=3
+KillMode=mixed
+Type=simple
+User=ubuntu
+Group=ubuntu
+
+[Install]
+WantedBy=multi-user.target

--- a/frootspi_examples/systemd/frootspi_netwatcher.sh
+++ b/frootspi_examples/systemd/frootspi_netwatcher.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+ip monitor link |
+while read -r line; do
+  if [[ $line == *'state UP'* ]]; then
+    # wait for ip address assign
+    for i in {1..30}; do
+      if [[ $(ip addr show wlan0) == *'inet '* ]]; then
+        echo "Network is up. Restarting robot_launch.service. "
+        sudo systemctl restart robot_launch.service
+        break
+      fi
+      sleep 1
+    done
+  elif [[ $line == *'state DOWN'* ]]; then
+    echo "Network is down."
+  fi
+done

--- a/frootspi_examples/systemd/register_systemd.sh
+++ b/frootspi_examples/systemd/register_systemd.sh
@@ -9,3 +9,7 @@ sudo systemctl start pigpiod.service
 sudo ln -s ${SCRIPT_DIR}/robot_launch.service /etc/systemd/system
 sudo systemctl enable robot_launch.service
 sudo systemctl start robot_launch.service
+
+sudo ln -s ${SCRIPT_DIR}/frootspi_netwatcher.service /etc/systemd/system
+sudo systemctl enable frootspi_netwatcher.service
+sudo systemctl start frootspi_netwatcher.service


### PR DESCRIPTION
初回起動時、およびネットワーク断時にROS2ネットワークから切断された状態になる問題があったため、ネットワーク再接続時にrobot_launch.serviceを再起動する仕組みを入れました