### PR TITLE
ハードウェア周りのTopicのPublish周期を下げた

### DIFF
--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -54,6 +54,7 @@ public:
 
 private:
   void on_high_rate_polling_timer();
+  void on_low_rate_polling_timer();
   void on_discharge_kicker_timer();
   void callback_dribble_power(const frootspi_msgs::msg::DribblePower::SharedPtr msg);
   void callback_wheel_velocities(const frootspi_msgs::msg::WheelVelocities::SharedPtr msg);
@@ -111,7 +112,8 @@ private:
   OnSetParametersCallbackHandle::SharedPtr set_parameters_callback_handle_;
 
 
-  rclcpp::TimerBase::SharedPtr polling_timer_;
+  rclcpp::TimerBase::SharedPtr high_rate_polling_timer_;
+  rclcpp::TimerBase::SharedPtr low_rate_polling_timer_;
   rclcpp::TimerBase::SharedPtr discharge_kicker_timer_;
   rclcpp::Clock steady_clock_;
   rclcpp::Time sub_wheel_timestamp_;
@@ -130,8 +132,13 @@ private:
   int front_display_prescaler_count_;
   int capacitor_monitor_prescaler_count_;
   FrontIndicateData front_indicate_data_;
+
   // sensor data store
   bool latest_ball_detection_;
+  float latest_battery_voltage_;
+  float latest_ups_voltage_;
+  float latest_kicker_voltage_;
+  frootspi_msgs::msg::SwitchesState latest_switches_state_;
 };
 
 }  // namespace frootspi_hardware

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -130,6 +130,8 @@ private:
   int front_display_prescaler_count_;
   int capacitor_monitor_prescaler_count_;
   FrontIndicateData front_indicate_data_;
+  // sensor data store
+  bool latest_ball_detection_;
 };
 
 }  // namespace frootspi_hardware

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -134,10 +134,13 @@ private:
 
   // sensor data store
   bool latest_ball_detection_;
-  float latest_battery_voltage_;
-  float latest_ups_voltage_;
-  float latest_kicker_voltage_;
-  frootspi_msgs::msg::SwitchesState latest_switches_state_;
+  bool latest_pushed_button0_;
+  bool latest_pushed_button1_;
+  bool latest_pushed_button2_;
+  bool latest_pushed_button3_;
+  bool latest_turned_on_dip0_;
+  bool latest_turned_on_dip1_;
+  bool latest_pushed_shutdown_;
 };
 
 }  // namespace frootspi_hardware

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -53,7 +53,7 @@ public:
   ~Driver();
 
 private:
-  void on_polling_timer();
+  void on_high_rate_polling_timer();
   void on_discharge_kicker_timer();
   void callback_dribble_power(const frootspi_msgs::msg::DribblePower::SharedPtr msg);
   void callback_wheel_velocities(const frootspi_msgs::msg::WheelVelocities::SharedPtr msg);

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -130,7 +130,6 @@ private:
   int discharge_kick_count_;
   WheelController wheel_controller_;
   int front_display_prescaler_count_;
-  int capacitor_monitor_prescaler_count_;
   FrontIndicateData front_indicate_data_;
 
   // sensor data store

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -316,20 +316,16 @@ void Driver::on_low_rate_polling_timer()
   pub_ups_voltage_->publish(std::move(ups_voltage_msg));
 
   // キッカー（昇圧回路）電圧をパブリッシュ
-  capacitor_monitor_prescaler_count_++;
-  if(capacitor_monitor_prescaler_count_ > 50){
-    auto kicker_voltage_msg = std::make_unique<frootspi_msgs::msg::BatteryVoltage>();
-    capacitor_monitor_.capacitor_info_read(
-      kicker_voltage_msg->voltage, kicker_voltage_msg->voltage_status);
-    front_indicate_data_.Parameter.CapVol = (unsigned char)(kicker_voltage_msg->voltage);
-    if(kicker_voltage_msg->voltage_status >= frootspi_msgs::msg::BatteryVoltage::BATTERY_VOLTAGE_STATUS_OK){
-      front_indicate_data_.Parameter.CapacitorSta = true;
-    } else {
-      front_indicate_data_.Parameter.CapacitorSta = false;
-    }
-    pub_kicker_voltage_->publish(std::move(kicker_voltage_msg));
-    capacitor_monitor_prescaler_count_ = 0;
+  auto kicker_voltage_msg = std::make_unique<frootspi_msgs::msg::BatteryVoltage>();
+  capacitor_monitor_.capacitor_info_read(
+    kicker_voltage_msg->voltage, kicker_voltage_msg->voltage_status);
+  front_indicate_data_.Parameter.CapVol = (unsigned char)(kicker_voltage_msg->voltage);
+  if(kicker_voltage_msg->voltage_status >= frootspi_msgs::msg::BatteryVoltage::BATTERY_VOLTAGE_STATUS_OK){
+    front_indicate_data_.Parameter.CapacitorSta = true;
+  } else {
+    front_indicate_data_.Parameter.CapacitorSta = false;
   }
+  pub_kicker_voltage_->publish(std::move(kicker_voltage_msg));
 }
 
 void Driver::on_discharge_kicker_timer()

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -57,6 +57,8 @@ Driver::Driver(const rclcpp::NodeOptions & options)
   // GPIOを定期的にread / writeするためのタイマー
   high_rate_polling_timer_ = create_wall_timer(1ms, std::bind(&Driver::on_high_rate_polling_timer, this));
   high_rate_polling_timer_->cancel();  // ノードがActiveになるまでタイマーオフ
+  low_rate_polling_timer_ = create_wall_timer(1000ms, std::bind(&Driver::on_low_rate_polling_timer, this));
+  low_rate_polling_timer_->cancel();  // ノードがActiveになるまでタイマーオフ
   // コンデンサ放電時に使うタイマー
   discharge_kicker_timer_ =
     create_wall_timer(500ms, std::bind(&Driver::on_discharge_kicker_timer, this));
@@ -327,6 +329,12 @@ void Driver::on_high_rate_polling_timer()
   //   front_display_communicator_.send_data(&front_indicate_data_);
   //   front_display_prescaler_count_ = 0;
   // }
+}
+
+
+void Driver::on_low_rate_polling_timer()
+{
+
 }
 
 void Driver::on_discharge_kicker_timer()

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -295,11 +295,7 @@ void Driver::on_polling_timer()
   pub_switches_state_->publish(std::move(switches_state_msg));
 
   // オムニホイール回転速度をパブリッシュ
-  auto wheel_velocities_msg = std::make_unique<frootspi_msgs::msg::WheelVelocities>();
-  wheel_velocities_msg->front_left = 1.0;  // 左前ホイール回転速度 [rad/sec]
-  wheel_velocities_msg->front_right = 1.0;  // 右前ホイール回転速度 [rad/sec]
-  wheel_velocities_msg->back_center = 1.0;  // 後ホイール回転速度 [rad/sec]
-  pub_present_wheel_velocities_->publish(std::move(wheel_velocities_msg));
+  // TODO: implement
 
   // IMUセンサの情報をパブリッシュ
 

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -181,6 +181,7 @@ Driver::Driver(const rclcpp::NodeOptions & options)
 
   // polling timer reset 
   high_rate_polling_timer_->reset();
+  low_rate_polling_timer_->reset();
 
   gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_HIGH);
 }
@@ -188,6 +189,7 @@ Driver::Driver(const rclcpp::NodeOptions & options)
 Driver::~Driver()
 {
   high_rate_polling_timer_->cancel();
+  low_rate_polling_timer_->cancel();
 
   gpio_write(pi_, GPIO_DRIBBLE_PWM, PI_HIGH);  // 負論理のためHighでモータオフ
   // lcd_driver_.write_texts("ROS 2", "SHUTDOWN");

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -246,11 +246,16 @@ rcl_interfaces::msg::SetParametersResult Driver::parametersCallback(
 
 void Driver::on_polling_timer()
 {
-  // ボール検出をパブリッシュ
+  // ボール検出 変化があった場合のみpublish
+  bool ball_detection = gpio_read(pi_, gpio_ball_sensor_);
+  if (ball_detection != this->latest_ball_detection_) 
+  {
   auto ball_detection_msg = std::make_unique<frootspi_msgs::msg::BallDetection>();
-  ball_detection_msg->detected = gpio_read(pi_, gpio_ball_sensor_);
-  front_indicate_data_.Parameter.BallSens = ball_detection_msg->detected;
+    ball_detection_msg->detected = ball_detection;
   pub_ball_detection_->publish(std::move(ball_detection_msg));
+  }
+  this->latest_ball_detection_ = ball_detection;
+  front_indicate_data_.Parameter.BallSens = ball_detection;
 
   // バッテリー電圧をパブリッシュ
   auto battery_voltage_msg = std::make_unique<frootspi_msgs::msg::BatteryVoltage>();

--- a/frootspi_kicker/src/frootspi_kicker_component.cpp
+++ b/frootspi_kicker/src/frootspi_kicker_component.cpp
@@ -183,7 +183,6 @@ void KickerNode::callback_kick_command(const frootspi_msgs::msg::KickCommand::Sh
   // キック可否判定 (ボールがあって、電圧が190V以上で、前回のキックは正常に行われている)
   RCLCPP_INFO(this->get_logger(), "kicer request.");
   if ((ball_detection_ == true) && 
-      (capacitor_voltage_ >= 190) && 
       (is_release_ == false) &&
       (is_kicking_ == false)) {
     set_kick(msg->kick_type, msg->kick_power);


### PR DESCRIPTION
あまりに高頻度(1ms)でトピックをPublishしていたため、この頻度を下げました

バッテリー電圧など、連続値かつそんなに高頻度で取得する必要のないものは 1sごと、
ボールセンサー、スイッチなど離散値のものは値が変化したときにのみPublishするようにしました