### PR TITLE
必ずネットワークが1秒以上確立してから再起動処理を行うように修正

### DIFF
--- a/frootspi_examples/systemd/frootspi_netwatcher.sh
+++ b/frootspi_examples/systemd/frootspi_netwatcher.sh
@@ -5,12 +5,12 @@ while read -r line; do
   if [[ $line == *'state UP'* ]]; then
     # wait for ip address assign
     for i in {1..30}; do
+      sleep 1
       if [[ $(ip addr show wlan0) == *'inet '* ]]; then
         echo "Network is up. Restarting robot_launch.service. "
         sudo systemctl restart robot_launch.service
         break
       fi
-      sleep 1
     done
   elif [[ $line == *'state DOWN'* ]]; then
     echo "Network is down."


### PR DESCRIPTION
RaspberryPiの起動時、1秒以内に複数回ネットワークの接続/接続断が行われ、短時間に繰り返しrobot_launch.serviceの再起動が行われる問題があったため、これを修正しました。