### PR TITLE
pigpiod終了時にハングアップしないよう、先にpidファイルを削除してからデーモンを止めるように変更

### DIFF
--- a/frootspi_examples/systemd/pigpiod.service
+++ b/frootspi_examples/systemd/pigpiod.service
@@ -3,8 +3,9 @@ Description=Pigpio daemon
 
 [Service]
 Type=simple
-PIDFile=pigpio.pid
+PIDFile=/var/run/pigpio.pid
 ExecStart=/usr/local/bin/pigpiod -g -s 1
+ExecStop=/bin/sh -c 'rm /var/run/pigpio.pid; killall pigpiod'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
pigpiodがハングアップして、シャットダウンに1分半ぐらいかかる問題を解消しました