### PR TITLE
キッカーのパルス制御を改善

### DIFF
--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -418,9 +418,6 @@ void Driver::on_kick(
   front_indicate_data_.Parameter.KickReq = true;
 
   if (request->kick_type == frootspi_msgs::srv::Kick::Request::KICK_TYPE_STRAIGHT) {
-    
-    gpio_write(pi_, GPIO_KICK_CHIP, PI_HIGH);
-
     // ストレートキック
     uint32_t sleep_time_usec = 673 * request->kick_power + 100; // constants based on test
     if (sleep_time_usec > MAX_SLEEP_TIME_USEC_FOR_STRAIGHT) {
@@ -486,8 +483,6 @@ void Driver::on_kick(
     response->message = "未定義のキックタイプです";
   }
   front_indicate_data_.Parameter.KickReq = false;
-  
-  gpio_write(pi_, GPIO_KICK_CHIP, PI_LOW);
 }
 
 void Driver::on_set_kicker_charging(

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -417,12 +417,19 @@ void Driver::on_kick(
 
   front_indicate_data_.Parameter.KickReq = true;
 
+
+
   if (request->kick_type == frootspi_msgs::srv::Kick::Request::KICK_TYPE_STRAIGHT) {
+    
+    gpio_write(pi_, GPIO_KICK_CHIP, PI_HIGH);
+
     // ストレートキック
     int sleep_time_usec = 673 * request->kick_power + 100; // constants based on test
     if (sleep_time_usec > MAX_SLEEP_TIME_USEC_FOR_STRAIGHT) {
       sleep_time_usec = MAX_SLEEP_TIME_USEC_FOR_STRAIGHT;
     }
+
+    sleep_time_usec = 1000; // test
 
     // キックをする際は充電を停止する
     gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
@@ -430,6 +437,7 @@ void Driver::on_kick(
     gpio_write(pi_, GPIO_KICK_STRAIGHT, PI_HIGH);
     rclcpp::sleep_for(std::chrono::microseconds(sleep_time_usec));
     gpio_write(pi_, GPIO_KICK_STRAIGHT, PI_LOW);
+
 
     if (enable_kicker_charging_) {
       // 充電許可が出ていれば、充電を再開する
@@ -458,6 +466,8 @@ void Driver::on_kick(
     response->message = "未定義のキックタイプです";
   }
   front_indicate_data_.Parameter.KickReq = false;
+  
+  gpio_write(pi_, GPIO_KICK_CHIP, PI_LOW);
 }
 
 void Driver::on_set_kicker_charging(


### PR DESCRIPTION
pigpioのwave機能を利用することで、次の課題を解消しました
- パルスON時間の精度
  - 修正前の実装では、指令値に対して+200us程度オフセットし、 標準偏差20us程度のON時間の乱れがありました。これがオフセット0, 標準偏差 1us以下になりました。
- パルス出力が同期処理になっている
  - 修正前の実装ではパルスON中の待ちが同期処理として実行されており、パルス出力中はロボット制御に関する他の処理が行えない問題がありました。wave機能を使ってpigpioにパルス出力処理を投げることで非同期化され、この問題が解消しました。

ソフト修正前と修正後の実験データはここにあります
https://docs.google.com/spreadsheets/d/1VuL7YN_mPdWvsKm7IyWaSpzysSDjz5s_5pSk3PVaMU4/edit#gid=0