### PR TITLE
キッカー関連コードのリファクタリング

### DIFF
--- a/frootspi_hardware/CMakeLists.txt
+++ b/frootspi_hardware/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(driver_component SHARED
   src/capacitor_monitor.cpp
   src/battery_monitor.cpp
   src/front_display_communicator.cpp
+  src/kicker.cpp
 )
 target_compile_definitions(driver_component
   PRIVATE "FROOTSPI_HARDWARE_BUILDING_DLL")

--- a/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/driver_component.hpp
@@ -28,6 +28,7 @@
 #include "frootspi_hardware/battery_monitor.hpp"
 #include "frootspi_hardware/front_display_communicator.hpp"
 #include "frootspi_hardware/wheel_controller.hpp"
+#include "frootspi_hardware/kicker.hpp"
 #include "frootspi_msgs/msg/ball_detection.hpp"
 #include "frootspi_msgs/msg/battery_voltage.hpp"
 #include "frootspi_msgs/msg/dribble_power.hpp"
@@ -58,7 +59,6 @@ public:
 private:
   void on_high_rate_polling_timer();
   void on_low_rate_polling_timer();
-  void on_discharge_kicker_timer();
   void callback_dribble_power(const frootspi_msgs::msg::DribblePower::SharedPtr msg);
   void callback_wheel_velocities(const frootspi_msgs::msg::WheelVelocities::SharedPtr msg);
   void on_kick(
@@ -119,7 +119,6 @@ private:
 
   rclcpp::TimerBase::SharedPtr high_rate_polling_timer_;
   rclcpp::TimerBase::SharedPtr low_rate_polling_timer_;
-  rclcpp::TimerBase::SharedPtr discharge_kicker_timer_;
   rclcpp::Clock steady_clock_;
   rclcpp::Time sub_wheel_timestamp_;
   bool timeout_has_printed_;
@@ -131,11 +130,10 @@ private:
   LCDDriver lcd_driver_;
   CapacitorMonitor capacitor_monitor_;
   FrontDisplayCommunicator front_display_communicator_;
-  bool enable_kicker_charging_;
-  int discharge_kick_count_;
   WheelController wheel_controller_;
   int front_display_prescaler_count_;
   FrontIndicateData front_indicate_data_;
+  Kicker kicker_;
 
   // sensor data store
   bool latest_ball_detection_;

--- a/frootspi_hardware/include/frootspi_hardware/kicker.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/kicker.hpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#ifndef FROOTSPI_HARDWARE__KICKER_HPP_
+#define FROOTSPI_HARDWARE__KICKER_HPP_
 
 #include <pigpiod_if2.h>
 #include "rclcpp/rclcpp.hpp"
@@ -26,19 +27,21 @@ const int GPIO_KICK_CHARGE_COMPLETE = 12;
 class Kicker
 {
 public:
-    Kicker();
-    ~Kicker();
+  Kicker();
+  ~Kicker();
 
-    bool open(int pi, int pin_ball_sensor);
-    void enableCharging();
-    void disableCharging();
-    bool discharge();
-    bool kickStraight(uint32_t powerMmps);
+  bool open(int pi, int pin_ball_sensor);
+  void enableCharging();
+  void disableCharging();
+  bool discharge();
+  bool kickStraight(uint32_t powerMmps);
 
 private:
-    bool cancelKick();
-    bool generateWave(gpioPulse_t *wave, size_t num_pulses);
+  bool cancelKick();
+  bool generateWave(gpioPulse_t * wave, size_t num_pulses);
 
-    int pi_;
-    bool is_charging_;
+  int pi_;
+  bool is_charging_;
 };
+
+#endif  // FROOTSPI_HARDWARE__KICKER_HPP_

--- a/frootspi_hardware/include/frootspi_hardware/kicker.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/kicker.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <pigpiod_if2.h>
 #include "rclcpp/rclcpp.hpp"
 
 const int GPIO_KICK_STRAIGHT = 7;
@@ -36,8 +37,7 @@ public:
 
 private:
     bool cancelKick();
-
-    rclcpp::TimerBase::SharedPtr discharge_kicker_timer_;
+    bool generateWave(gpioPulse_t *wave, size_t num_pulses);
 
     int pi_;
     bool is_charging_;

--- a/frootspi_hardware/include/frootspi_hardware/kicker.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/kicker.hpp
@@ -1,0 +1,42 @@
+// Copyright 2024 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "rclcpp/rclcpp.hpp"
+
+const int GPIO_KICK_STRAIGHT = 7;
+const int GPIO_KICK_CHIP = 24;
+const int GPIO_KICK_SUPPLY_POWER = 5;
+const int GPIO_KICK_ENABLE_CHARGE = 26;
+const int GPIO_KICK_CHARGE_COMPLETE = 12;
+
+class Kicker
+{
+public:
+    Kicker();
+    ~Kicker();
+
+    bool open(int pi, int pin_ball_sensor);
+    void enableCharging();
+    void disableCharging();
+    bool discharge();
+    bool kickStraight(uint32_t powerMmps);
+
+private:
+    rclcpp::TimerBase::SharedPtr discharge_kicker_timer_;
+
+    int pi_;
+    bool is_charging_;
+};

--- a/frootspi_hardware/include/frootspi_hardware/kicker.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/kicker.hpp
@@ -35,6 +35,8 @@ public:
     bool kickStraight(uint32_t powerMmps);
 
 private:
+    bool cancelKick();
+
     rclcpp::TimerBase::SharedPtr discharge_kicker_timer_;
 
     int pi_;

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -425,8 +425,6 @@ void Driver::on_set_kicker_charging(
   const frootspi_msgs::srv::SetKickerCharging::Request::SharedPtr request,
   frootspi_msgs::srv::SetKickerCharging::Response::SharedPtr response)
 {
-  // キッカーの充電はキック処理時にON/OFFされるので、
-  // enable_kicker_charging_ 変数で充電フラグを管理する
   if (request->start_charging) {
     kicker_.enableCharging();
     RCLCPP_INFO(this->get_logger(), "キッカーの充電開始.");

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -348,7 +348,6 @@ void Driver::on_low_rate_polling_timer()
 }
 
 
-
 void Driver::callback_dribble_power(const frootspi_msgs::msg::DribblePower::SharedPtr msg)
 {
   double power = msg->power;

--- a/frootspi_hardware/src/kicker.cpp
+++ b/frootspi_hardware/src/kicker.cpp
@@ -1,0 +1,153 @@
+// Copyright 2024 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pigpiod_if2.h>
+#include <chrono>
+
+#include "frootspi_hardware/kicker.hpp"
+
+
+Kicker::Kicker() :
+    is_charging_(false)
+{
+}
+
+Kicker::~Kicker()
+{
+  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
+  gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_LOW);
+}
+
+bool Kicker::open(int pi, int pin_ball_sensor)
+{
+    this->pi_ = pi;
+
+    // ball sensor setup
+    set_mode(pi_, pin_ball_sensor, PI_INPUT);
+    set_pull_up_down(pi_, pin_ball_sensor, PI_PUD_UP);
+
+    // kicker setup
+    set_mode(pi_, GPIO_KICK_STRAIGHT, PI_OUTPUT);
+    gpio_write(pi_, GPIO_KICK_STRAIGHT, PI_LOW);
+    set_mode(pi_, GPIO_KICK_CHIP, PI_OUTPUT);
+    gpio_write(pi_, GPIO_KICK_CHIP, PI_LOW);
+    set_mode(pi_, GPIO_KICK_SUPPLY_POWER, PI_OUTPUT);
+    gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_LOW);
+    set_mode(pi_, GPIO_KICK_ENABLE_CHARGE, PI_OUTPUT);
+    gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
+    set_mode(pi_, GPIO_KICK_CHARGE_COMPLETE, PI_INPUT);
+    set_pull_up_down(pi_, GPIO_KICK_CHARGE_COMPLETE, PI_PUD_UP);  // 外部プルアップあり
+    gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_HIGH);
+
+    return true;
+}
+
+
+bool Kicker::kickStraight(uint32_t powerMmps)
+{
+  const int MAX_SLEEP_TIME_USEC_FOR_STRAIGHT = 30000;
+    // ストレートキック
+
+    uint32_t sleep_time_usec = 4 * powerMmps + 100;  // constants based on test
+    if (sleep_time_usec > MAX_SLEEP_TIME_USEC_FOR_STRAIGHT) {
+      sleep_time_usec = MAX_SLEEP_TIME_USEC_FOR_STRAIGHT;
+    }
+
+    // GPIOをHIGHにしている時間を変化させて、キックパワーを変更する
+    uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
+    uint32_t bit_kick_enable_charge = 1 << GPIO_KICK_ENABLE_CHARGE;
+    uint32_t bit_kick_enable_charge_masked = this->is_charging_ ? bit_kick_enable_charge : 0;
+
+    gpioPulse_t pulses[] = {
+      {0, bit_kick_enable_charge, 100},                                           // 充電を停止する
+      {bit_kick_straight, 0, sleep_time_usec},                                    // キックON
+      {0, bit_kick_straight, 100},                                                // キックOFF
+      {bit_kick_enable_charge_masked, 0, 0},                                      // 充電を再開する
+    };
+
+    wave_clear(pi_);
+    int num_pulse = wave_add_generic(pi_, sizeof(pulses) / sizeof(gpioPulse_t), pulses);
+    if (num_pulse < 0) {
+        return false;
+    }
+
+    int wave_id = wave_create(pi_);
+    if (wave_id < 0) {
+        return false;
+    }
+
+    int result = wave_send_once(pi_, wave_id);
+    if (result < 0) {
+        return false;
+    }
+
+    return true;
+}
+
+void Kicker:: enableCharging()
+{
+    gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
+    this->is_charging_ = true;
+}
+
+
+void Kicker:: disableCharging()
+{
+    gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
+    this->is_charging_ = false;
+}
+
+
+bool Kicker::discharge()
+{
+    uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
+    uint32_t bit_kick_enable_charge = 1 << GPIO_KICK_ENABLE_CHARGE;
+
+    uint32_t ontime_us = 1000;
+    uint32_t cycle_us = 1000 * 1000;
+
+    gpioPulse_t pulses[] = {
+      {0, bit_kick_enable_charge, 100},                                           // 充電を停止する
+      {bit_kick_straight, 0, ontime_us},
+      {0, bit_kick_straight, cycle_us - ontime_us},
+      {bit_kick_straight, 0, ontime_us},
+      {0, bit_kick_straight, cycle_us - ontime_us},
+      {bit_kick_straight, 0, ontime_us},
+      {0, bit_kick_straight, cycle_us - ontime_us},
+      {bit_kick_straight, 0, ontime_us},
+      {0, bit_kick_straight, cycle_us - ontime_us},
+      {bit_kick_straight, 0, ontime_us},
+      {0, bit_kick_straight, cycle_us - ontime_us},
+      {bit_kick_straight, 0, ontime_us},
+      {0, bit_kick_straight, cycle_us - ontime_us},
+    };
+
+    wave_clear(pi_);
+    int num_pulse = wave_add_generic(pi_, sizeof(pulses) / sizeof(gpioPulse_t), pulses);
+    if (num_pulse < 0) {
+        return false;
+    }
+
+    int wave_id = wave_create(pi_);
+    if (wave_id < 0) {
+        return false;
+    }
+
+    int result = wave_send_once(pi_, wave_id);
+    if (result < 0) {
+        return false;
+    }
+
+    return true;
+}

--- a/frootspi_hardware/src/kicker.cpp
+++ b/frootspi_hardware/src/kicker.cpp
@@ -140,8 +140,36 @@ bool Kicker::discharge()
     if (result < 0) {
         return false;
     }
-
+    
     this->is_charging_ = false;
+
+    return true;
+}
+
+
+bool Kicker::cancelKick()
+{
+    uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
+
+    gpioPulse_t pulses[] = {
+      {0, bit_kick_straight, 1}, // キックOFF
+    };
+
+    wave_clear(pi_);
+    int num_pulse = wave_add_generic(pi_, sizeof(pulses) / sizeof(gpioPulse_t), pulses);
+    if (num_pulse < 0) {
+        return false;
+    }
+
+    int wave_id = wave_create(pi_);
+    if (wave_id < 0) {
+        return false;
+    }
+
+    int result = wave_send_once(pi_, wave_id);
+    if (result < 0) {
+        return false;
+    }
 
     return true;
 }

--- a/frootspi_hardware/src/kicker.cpp
+++ b/frootspi_hardware/src/kicker.cpp
@@ -84,6 +84,11 @@ bool Kicker::kickStraight(uint32_t powerMmps)
 
 void Kicker:: enableCharging()
 {
+    if (this->is_charging_) {
+        return;
+    }
+
+    this->cancelKick();
     gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
     this->is_charging_ = true;
 }
@@ -91,6 +96,11 @@ void Kicker:: enableCharging()
 
 void Kicker:: disableCharging()
 {
+    if (!this->is_charging_) {
+        return;
+    }
+
+    this->cancelKick();
     gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
     this->is_charging_ = false;
 }

--- a/frootspi_hardware/src/kicker.cpp
+++ b/frootspi_hardware/src/kicker.cpp
@@ -17,8 +17,8 @@
 /**
  * @brief コンストラクタ。キッカーの初期化を行います。
  */
-Kicker::Kicker() :
-    is_charging_(false)
+Kicker::Kicker()
+: is_charging_(false)
 {
 }
 
@@ -41,26 +41,26 @@ Kicker::~Kicker()
  */
 bool Kicker::open(int pi, int pin_ball_sensor)
 {
-    this->pi_ = pi;
+  this->pi_ = pi;
 
-    // ボールセンサーの設定
-    set_mode(pi_, pin_ball_sensor, PI_INPUT);
-    set_pull_up_down(pi_, pin_ball_sensor, PI_PUD_UP);
+  // ボールセンサーの設定
+  set_mode(pi_, pin_ball_sensor, PI_INPUT);
+  set_pull_up_down(pi_, pin_ball_sensor, PI_PUD_UP);
 
-    // キッカーの設定
-    set_mode(pi_, GPIO_KICK_STRAIGHT, PI_OUTPUT);
-    gpio_write(pi_, GPIO_KICK_STRAIGHT, PI_LOW);
-    set_mode(pi_, GPIO_KICK_CHIP, PI_OUTPUT);
-    gpio_write(pi_, GPIO_KICK_CHIP, PI_LOW);
-    set_mode(pi_, GPIO_KICK_SUPPLY_POWER, PI_OUTPUT);
-    gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_LOW);
-    set_mode(pi_, GPIO_KICK_ENABLE_CHARGE, PI_OUTPUT);
-    gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
-    set_mode(pi_, GPIO_KICK_CHARGE_COMPLETE, PI_INPUT);
-    set_pull_up_down(pi_, GPIO_KICK_CHARGE_COMPLETE, PI_PUD_UP);  // 外部プルアップあり
-    gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_HIGH);
+  // キッカーの設定
+  set_mode(pi_, GPIO_KICK_STRAIGHT, PI_OUTPUT);
+  gpio_write(pi_, GPIO_KICK_STRAIGHT, PI_LOW);
+  set_mode(pi_, GPIO_KICK_CHIP, PI_OUTPUT);
+  gpio_write(pi_, GPIO_KICK_CHIP, PI_LOW);
+  set_mode(pi_, GPIO_KICK_SUPPLY_POWER, PI_OUTPUT);
+  gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_LOW);
+  set_mode(pi_, GPIO_KICK_ENABLE_CHARGE, PI_OUTPUT);
+  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
+  set_mode(pi_, GPIO_KICK_CHARGE_COMPLETE, PI_INPUT);
+  set_pull_up_down(pi_, GPIO_KICK_CHARGE_COMPLETE, PI_PUD_UP);    // 外部プルアップあり
+  gpio_write(pi_, GPIO_KICK_SUPPLY_POWER, PI_HIGH);
 
-    return true;
+  return true;
 }
 
 /**
@@ -104,13 +104,13 @@ bool Kicker::kickStraight(uint32_t powerMmps)
  */
 void Kicker::enableCharging()
 {
-    if (this->is_charging_) {
-        return;
-    }
+  if (this->is_charging_) {
+    return;
+  }
 
-    this->cancelKick();
-    gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
-    this->is_charging_ = true;
+  this->cancelKick();
+  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
+  this->is_charging_ = true;
 }
 
 /**
@@ -118,13 +118,13 @@ void Kicker::enableCharging()
  */
 void Kicker::disableCharging()
 {
-    if (!this->is_charging_) {
-        return;
-    }
+  if (!this->is_charging_) {
+    return;
+  }
 
-    this->cancelKick();
-    gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
-    this->is_charging_ = false;
+  this->cancelKick();
+  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
+  this->is_charging_ = false;
 }
 
 /**
@@ -135,27 +135,28 @@ void Kicker::disableCharging()
  */
 bool Kicker::discharge()
 {
-    uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
-    uint32_t bit_kick_enable_charge = 1 << GPIO_KICK_ENABLE_CHARGE;
+  uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
+  uint32_t bit_kick_enable_charge = 1 << GPIO_KICK_ENABLE_CHARGE;
 
-    const uint32_t ontime_us = 1000;
-    const uint32_t cycle_us = 500 * 1000;
-    const size_t num_discharge = 60;
+  const uint32_t ontime_us = 1000;
+  const uint32_t cycle_us = 500 * 1000;
+  const size_t num_discharge = 60;
+  const size_t kPulseArrayLength = num_discharge * 2 + 1;
 
-    gpioPulse_t pulses[num_discharge*2 + 1];
-    pulses[0] = {0, bit_kick_enable_charge, 100};   // 充電をOFF
-    for(size_t i=0; i<num_discharge; i++) {
-      pulses[i*2+1] = {bit_kick_straight, 0, ontime_us};
-      pulses[i*2+2] = {0, bit_kick_straight, cycle_us - ontime_us};
-    }
+  gpioPulse_t pulses[kPulseArrayLength];
+  pulses[0] = {0, bit_kick_enable_charge, 100};     // 充電をOFF
+  for (size_t i = 0; i < num_discharge; i++) {
+    pulses[i * 2 + 1] = {bit_kick_straight, 0, ontime_us};
+    pulses[i * 2 + 2] = {0, bit_kick_straight, cycle_us - ontime_us};
+  }
 
-    bool gen_result = this->generateWave(pulses, sizeof(pulses) / sizeof(gpioPulse_t));
-    if (!gen_result) {
-        return false;
-    }
+  bool gen_result = this->generateWave(pulses, kPulseArrayLength);
+  if (!gen_result) {
+    return false;
+  }
 
-    this->is_charging_ = false;
-    return true;
+  this->is_charging_ = false;
+  return true;
 }
 
 /**
@@ -166,13 +167,13 @@ bool Kicker::discharge()
  */
 bool Kicker::cancelKick()
 {
-    uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
+  uint32_t bit_kick_straight = 1 << GPIO_KICK_STRAIGHT;
 
-    gpioPulse_t pulses[] = {
-      {0, bit_kick_straight, 1}, // キックOFF
-    };
+  gpioPulse_t pulses[] = {
+    {0, bit_kick_straight, 1},   // キックOFF
+  };
 
-    return this->generateWave(pulses, sizeof(pulses) / sizeof(gpioPulse_t));
+  return this->generateWave(pulses, sizeof(pulses) / sizeof(gpioPulse_t));
 }
 
 /**
@@ -183,25 +184,25 @@ bool Kicker::cancelKick()
  * @return true 波形の生成に成功した場合。
  * @return false 波形の生成に失敗した場合。
  */
-bool Kicker::generateWave(gpioPulse_t *wave, size_t num_pulses)
+bool Kicker::generateWave(gpioPulse_t * wave, size_t num_pulses)
 {
-    wave_clear(pi_);
-    int num_pulse = wave_add_generic(pi_, num_pulses, wave);
-    if (num_pulse < 0) {
-        return false;
-    }
+  wave_clear(pi_);
+  int num_pulse = wave_add_generic(pi_, num_pulses, wave);
+  if (num_pulse < 0) {
+    return false;
+  }
 
-    int wave_id = wave_create(pi_);
-    if (wave_id < 0) {
-        return false;
-    }
+  int wave_id = wave_create(pi_);
+  if (wave_id < 0) {
+    return false;
+  }
 
-    int result = wave_send_once(pi_, wave_id);
-    if (result < 0) {
-        return false;
-    }
+  int result = wave_send_once(pi_, wave_id);
+  if (result < 0) {
+    return false;
+  }
 
-    wave_delete(pi_, wave_id);  // wave の数が無限に増えないよう逐次削除
+  wave_delete(pi_, wave_id);    // wave の数が無限に増えないよう逐次削除
                                 // waveのバッファから消えるだけで、波形自体は出る
-    return true;
+  return true;
 }


### PR DESCRIPTION
キッカー関連コードのリファクタリングを実施しました。

driver_component.cpp から kicker.cpp に、キッカー関連の処理を切り出しました。  
また、放電処理のタイマーをなくすため、 pigpioのwave機能を使うようにしました。