### PR TITLE
テストモードを実装

### DIFF
--- a/frootspi_hardware/include/frootspi_hardware/dribbler.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/dribbler.hpp
@@ -33,8 +33,15 @@ public:
 
   bool drive(double power);
 
+  void enableDebugMode();
+  void diasbleDebugMode();
+  bool debugDrive(double power);
+
 private:
   int pi_;
+  bool debug_mode_;
+
+  bool drive_(double power);
 };
 
 #endif  // FROOTSPI_HARDWARE__DRIBBLER_HPP_

--- a/frootspi_hardware/include/frootspi_hardware/kicker.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/kicker.hpp
@@ -31,17 +31,25 @@ public:
   ~Kicker();
 
   bool open(int pi, int pin_ball_sensor);
-  void enableCharging();
-  void disableCharging();
+  bool enableCharging();
+  bool disableCharging();
   bool discharge();
   bool kickStraight(uint32_t powerMmps);
+
+  void enableDebugMode();
+  void disableDebugMode();
+  void debugEnableCharging();
+  void debugDisableCharging();
 
 private:
   bool cancelKick();
   bool generateWave(gpioPulse_t * wave, size_t num_pulses);
+  bool enableCharging_();
+  bool disableCharging_();
 
   int pi_;
   bool is_charging_;
+  bool debug_mode_;
 };
 
 #endif  // FROOTSPI_HARDWARE__KICKER_HPP_

--- a/frootspi_hardware/include/frootspi_hardware/wheel_controller.hpp
+++ b/frootspi_hardware/include/frootspi_hardware/wheel_controller.hpp
@@ -21,10 +21,16 @@ public:
   enum ErrorCode
   {
     ERROR_NONE = 0,
-    ERROR_GAIN_SETTING_MODE_ENABLED,
-    ERROR_GAIN_SETTING_MODE_DISABLED,
+    ERROR_INVALID_MODE,
     ERROR_CAN_SEND_FAILED,
     ERROR_WHEELS_ARE_MOVING,
+  };
+
+  enum Mode
+  {
+    NORMAL_MODE = 0,
+    GAIN_SETTING_MODE,
+    DEBUG_MODE,
   };
 
   WheelController();
@@ -36,8 +42,8 @@ public:
     const double vel_front_right, const double vel_front_left,
     const double vel_back_center);
 
-  ErrorCode enable_gain_setting();
-  ErrorCode disable_gain_setting();
+  ErrorCode set_mode(Mode);
+
   ErrorCode set_p_gain(const double gain_p);
   ErrorCode set_i_gain(const double gain_i);
   ErrorCode set_d_gain(const double gain_d);
@@ -45,16 +51,23 @@ public:
     const double gain_p, const double gain_i,
     const double gain_d);
 
+  ErrorCode debug_set_wheel_velocities(
+    const double vel_front_right, const double vel_front_left,
+    const double vel_back_center);
+
 private:
   bool send_pid_gain();
   bool send_can(const struct can_frame & frame);
   double constrain(const double value, const double min, const double max);
   bool is_motor_stopping();
+  ErrorCode set_wheel_velocities_(
+    const double vel_front_right, const double vel_front_left,
+    const double vel_back_center);
 
   int socket_;
   double vel_front_right_, vel_front_left_, vel_back_center_;
   double gain_p_, gain_i_, gain_d_;
-  bool is_gain_setting_enabled_;
+  Mode mode_;
 };
 
 #endif  // FROOTSPI_HARDWARE__WHEEL_CONTROLLER_HPP_

--- a/frootspi_hardware/src/dribbler.cpp
+++ b/frootspi_hardware/src/dribbler.cpp
@@ -18,6 +18,7 @@
  * @brief コンストラクタ。ドリブラーの初期化を行います。
  */
 Dribbler::Dribbler()
+: debug_mode_(false)
 {
 }
 
@@ -60,6 +61,46 @@ void Dribbler::close()
  * @param power ドリブラーの駆動力。0.0で停止、1.0で最大出力。
  */
 bool Dribbler::drive(double power)
+{
+  if (this->debug_mode_) return false;
+  return this->drive_(power);
+}
+
+/**
+ * @brief デバッグモードを有効にする。
+ */
+void Dribbler::enableDebugMode()
+{
+  this->debug_mode_ = true;
+}
+
+/**
+ * @brief デバッグモードを無効にする。
+ */
+void Dribbler::diasbleDebugMode()
+{
+  this->debug_mode_ = false;
+}
+
+
+/**
+ * @brief ドリブラーをデバッグモードで駆動する。
+ * 
+ * @param power ドリブラーの駆動力。0.0で停止、1.0で最大出力。
+ */
+bool Dribbler::debugDrive(double power)
+{
+  if (!this->debug_mode_) return false;
+  return this->drive_(power);
+}
+
+
+/**
+ * @brief ドリブラーを駆動する。
+ *
+ * @param power ドリブラーの駆動力。0.0で停止、1.0で最大出力。
+ */
+bool Dribbler::drive_(double power)
 {
   if (power > 1.0) {
     power = 1.0;

--- a/frootspi_hardware/src/dribbler.cpp
+++ b/frootspi_hardware/src/dribbler.cpp
@@ -62,7 +62,7 @@ void Dribbler::close()
  */
 bool Dribbler::drive(double power)
 {
-  if (this->debug_mode_) return false;
+  if (this->debug_mode_) {return false;}
   return this->drive_(power);
 }
 
@@ -85,12 +85,12 @@ void Dribbler::diasbleDebugMode()
 
 /**
  * @brief ドリブラーをデバッグモードで駆動する。
- * 
+ *
  * @param power ドリブラーの駆動力。0.0で停止、1.0で最大出力。
  */
 bool Dribbler::debugDrive(double power)
 {
-  if (!this->debug_mode_) return false;
+  if (!this->debug_mode_) {return false;}
   return this->drive_(power);
 }
 

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -279,6 +279,15 @@ void Driver::on_high_rate_polling_timer()
       this->wheel_controller_.set_mode(WheelController::NORMAL_MODE);
     }
 
+    // ドリブラー
+    if (pushed_button2) {
+      this->dribbler_.enableDebugMode();
+      this->dribbler_.debugDrive(1.0);
+    } else {
+      this->dribbler_.debugDrive(0.0);
+      this->dribbler_.diasbleDebugMode();
+    }
+
     // キッカー
     if (pushed_button1) {
       this->kicker_.enableDebugMode();

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -205,7 +205,7 @@ rcl_interfaces::msg::SetParametersResult Driver::parametersCallback(
   if (gain_setting_result == WheelController::ErrorCode::ERROR_NONE) {
     result.successful = true;
     result.reason = "success";
-  } else if (gain_setting_result == WheelController::ErrorCode::ERROR_GAIN_SETTING_MODE_DISABLED) {
+  } else if (gain_setting_result == WheelController::ErrorCode::ERROR_INVALID_MODE) {
     result.successful = false;
     result.reason = "ゲイン設定モードが無効になっています";
   } else if (gain_setting_result == WheelController::ErrorCode::ERROR_CAN_SEND_FAILED) {
@@ -266,6 +266,27 @@ void Driver::on_high_rate_polling_timer()
     this->latest_turned_on_dip0_ = turned_on_dip0;
     this->latest_turned_on_dip1_ = turned_on_dip1;
     this->latest_pushed_shutdown_ = pushed_shutdown;
+
+    /**
+     * デバッグモード設定
+    */
+    // 車輪
+    if (pushed_button3) {
+      this->wheel_controller_.set_mode(WheelController::DEBUG_MODE);
+      this->wheel_controller_.debug_set_wheel_velocities(10.0, 10.0, 10.0);
+    } else {
+      this->wheel_controller_.debug_set_wheel_velocities(0.0, 0.0, 0.0);
+      this->wheel_controller_.set_mode(WheelController::NORMAL_MODE);
+    }
+
+    // キッカー
+    if (pushed_button1) {
+      this->kicker_.enableDebugMode();
+      this->kicker_.debugEnableCharging();
+    } else {
+      this->kicker_.debugDisableCharging();
+      this->kicker_.disableDebugMode();
+    }
   }
 
   // オムニホイール回転速度をパブリッシュ
@@ -496,7 +517,7 @@ void Driver::on_enable_gain_setting(
 {
   if (request->data) {
     // ゲイン設定を有効にする
-    WheelController::ErrorCode error_code = wheel_controller_.enable_gain_setting();
+    WheelController::ErrorCode error_code = wheel_controller_.set_mode(WheelController::GAIN_SETTING_MODE);
     if (error_code == WheelController::ErrorCode::ERROR_NONE) {
       response->success = true;
       response->message = "ゲイン設定モードを有効にしました。車輪が回らなくなります。";
@@ -506,7 +527,7 @@ void Driver::on_enable_gain_setting(
     }
   } else {
     // ゲイン設定を無効にする
-    WheelController::ErrorCode error_code = wheel_controller_.disable_gain_setting();
+    WheelController::ErrorCode error_code = wheel_controller_.set_mode(WheelController::NORMAL_MODE);
     if (error_code == WheelController::ErrorCode::ERROR_NONE) {
       response->success = true;
       response->message = "ゲイン設定モードを無効にしました。車輪が回せます。";

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -531,7 +531,8 @@ void Driver::on_enable_gain_setting(
 {
   if (request->data) {
     // ゲイン設定を有効にする
-    WheelController::ErrorCode error_code = wheel_controller_.set_mode(WheelController::GAIN_SETTING_MODE);
+    WheelController::ErrorCode error_code = wheel_controller_.set_mode(
+      WheelController::GAIN_SETTING_MODE);
     if (error_code == WheelController::ErrorCode::ERROR_NONE) {
       response->success = true;
       response->message = "ゲイン設定モードを有効にしました。車輪が回らなくなります。";
@@ -541,7 +542,8 @@ void Driver::on_enable_gain_setting(
     }
   } else {
     // ゲイン設定を無効にする
-    WheelController::ErrorCode error_code = wheel_controller_.set_mode(WheelController::NORMAL_MODE);
+    WheelController::ErrorCode error_code =
+      wheel_controller_.set_mode(WheelController::NORMAL_MODE);
     if (error_code == WheelController::ErrorCode::ERROR_NONE) {
       response->success = true;
       response->message = "ゲイン設定モードを無効にしました。車輪が回せます。";

--- a/frootspi_hardware/src/driver_component.cpp
+++ b/frootspi_hardware/src/driver_component.cpp
@@ -296,6 +296,11 @@ void Driver::on_high_rate_polling_timer()
       this->kicker_.debugDisableCharging();
       this->kicker_.disableDebugMode();
     }
+
+    // 放電スイッチ
+    if (pushed_button0) {
+      this->kicker_.discharge();
+    }
   }
 
   // オムニホイール回転速度をパブリッシュ

--- a/frootspi_hardware/src/kicker.cpp
+++ b/frootspi_hardware/src/kicker.cpp
@@ -74,6 +74,8 @@ bool Kicker::kickStraight(uint32_t powerMmps)
 {
   const int MAX_SLEEP_TIME_USEC_FOR_STRAIGHT = 30000;
 
+  if (this->debug_mode_)  return false;
+
   uint32_t sleep_time_usec = 4 * powerMmps + 100;  // 実験に基づく定数
   if (sleep_time_usec > MAX_SLEEP_TIME_USEC_FOR_STRAIGHT) {
     sleep_time_usec = MAX_SLEEP_TIME_USEC_FOR_STRAIGHT;
@@ -101,30 +103,24 @@ bool Kicker::kickStraight(uint32_t powerMmps)
 
 /**
  * @brief 充電を有効にします。
+ * @return true 充電許可に成功した場合。
+ * @return false 充電許可に失敗した場合。
  */
-void Kicker::enableCharging()
+bool Kicker::enableCharging()
 {
-  if (this->is_charging_) {
-    return;
-  }
-
-  this->cancelKick();
-  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
-  this->is_charging_ = true;
+  if (this->debug_mode_) return false;
+  return this->enableCharging_();
 }
 
 /**
  * @brief 充電を無効にします。
+ * @return true 充電禁止に成功した場合。
+ * @return false 充電禁止に失敗した場合。
  */
-void Kicker::disableCharging()
+bool Kicker::disableCharging()
 {
-  if (!this->is_charging_) {
-    return;
-  }
-
-  this->cancelKick();
-  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
-  this->is_charging_ = false;
+  if (this->debug_mode_) return false;
+  return this->disableCharging_();
 }
 
 /**
@@ -158,6 +154,43 @@ bool Kicker::discharge()
   this->is_charging_ = false;
   return true;
 }
+
+/**
+ * @brief デバッグモードを有効にします。
+ */
+void Kicker::enableDebugMode()
+{
+  this->debug_mode_ = true;
+}
+
+/**
+ * @brief デバッグモードを無効にします。
+ */
+void Kicker::disableDebugMode()
+{
+  this->debug_mode_ = false;
+}
+
+/**
+ * @brief デバッグモードで充電を有効にします。
+ * @return true 充電許可に成功した場合。
+ * @return false 充電許可に失敗した場合。
+ */
+void Kicker::debugEnableCharging()
+{
+  this->enableCharging_();
+}
+
+/**
+ * @brief デバッグモードで充電を無効にします。
+ * @return true 充電禁止に成功した場合。
+ * @return false 充電禁止に失敗した場合。
+ */
+void Kicker::debugDisableCharging()
+{
+  this->disableCharging_();
+}
+
 
 /**
  * @brief キックをキャンセルします。
@@ -204,5 +237,37 @@ bool Kicker::generateWave(gpioPulse_t * wave, size_t num_pulses)
 
   wave_delete(pi_, wave_id);    // wave の数が無限に増えないよう逐次削除
                                 // waveのバッファから消えるだけで、波形自体は出る
+  return true;
+}
+
+/**
+ * @brief 充電を有効にします。
+ * @return true 充電許可に成功した場合。
+ * @return false 充電許可に失敗した場合。
+ */
+bool Kicker::enableCharging_()
+{
+  if (this->is_charging_) return false;
+
+  this->cancelKick();
+  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
+  this->is_charging_ = true;
+
+  return true;
+}
+
+/**
+ * @brief 充電を無効にします。
+ * @return true 充電禁止に成功した場合。
+ * @return false 充電禁止に失敗した場合。
+ */
+bool Kicker::disableCharging_()
+{
+  if (!this->is_charging_) return false;
+
+  this->cancelKick();
+  gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);
+  this->is_charging_ = false;
+
   return true;
 }

--- a/frootspi_hardware/src/kicker.cpp
+++ b/frootspi_hardware/src/kicker.cpp
@@ -74,7 +74,7 @@ bool Kicker::kickStraight(uint32_t powerMmps)
 {
   const int MAX_SLEEP_TIME_USEC_FOR_STRAIGHT = 30000;
 
-  if (this->debug_mode_)  return false;
+  if (this->debug_mode_) {return false;}
 
   uint32_t sleep_time_usec = 4 * powerMmps + 100;  // 実験に基づく定数
   if (sleep_time_usec > MAX_SLEEP_TIME_USEC_FOR_STRAIGHT) {
@@ -108,7 +108,7 @@ bool Kicker::kickStraight(uint32_t powerMmps)
  */
 bool Kicker::enableCharging()
 {
-  if (this->debug_mode_) return false;
+  if (this->debug_mode_) {return false;}
   return this->enableCharging_();
 }
 
@@ -119,7 +119,7 @@ bool Kicker::enableCharging()
  */
 bool Kicker::disableCharging()
 {
-  if (this->debug_mode_) return false;
+  if (this->debug_mode_) {return false;}
   return this->disableCharging_();
 }
 
@@ -247,7 +247,7 @@ bool Kicker::generateWave(gpioPulse_t * wave, size_t num_pulses)
  */
 bool Kicker::enableCharging_()
 {
-  if (this->is_charging_) return false;
+  if (this->is_charging_) {return false;}
 
   this->cancelKick();
   gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_HIGH);
@@ -263,7 +263,7 @@ bool Kicker::enableCharging_()
  */
 bool Kicker::disableCharging_()
 {
-  if (!this->is_charging_) return false;
+  if (!this->is_charging_) {return false;}
 
   this->cancelKick();
   gpio_write(pi_, GPIO_KICK_ENABLE_CHARGE, PI_LOW);

--- a/frootspi_hardware/src/wheel_controller.cpp
+++ b/frootspi_hardware/src/wheel_controller.cpp
@@ -87,7 +87,7 @@ bool WheelController::device_close()
 WheelController::ErrorCode WheelController::set_wheel_velocities(
   const double vel_front_right, const double vel_front_left, const double vel_back_center)
 {
-  if (this->mode_ != WheelController::NORMAL_MODE) return WheelController::ERROR_INVALID_MODE;
+  if (this->mode_ != WheelController::NORMAL_MODE) {return WheelController::ERROR_INVALID_MODE;}
   return this->set_wheel_velocities_(vel_front_right, vel_front_left, vel_back_center);
 }
 
@@ -110,7 +110,6 @@ WheelController::ErrorCode WheelController::set_mode(WheelController::Mode mode)
 }
 
 
-
 /**
  * @brief Pゲインを設定する
  * @param[in] gain_p Pゲイン
@@ -121,7 +120,9 @@ WheelController::ErrorCode WheelController::set_mode(WheelController::Mode mode)
 */
 WheelController::ErrorCode WheelController::set_p_gain(const double gain_p)
 {
-  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE) {
+    return WheelController::ERROR_INVALID_MODE;
+  }
 
   gain_p_ = gain_p;
   bool send_result;
@@ -143,7 +144,9 @@ WheelController::ErrorCode WheelController::set_p_gain(const double gain_p)
 */
 WheelController::ErrorCode WheelController::set_i_gain(const double gain_i)
 {
-  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE) {
+    return WheelController::ERROR_INVALID_MODE;
+  }
 
   gain_i_ = gain_i;
   bool send_result;
@@ -165,7 +168,9 @@ WheelController::ErrorCode WheelController::set_i_gain(const double gain_i)
 */
 WheelController::ErrorCode WheelController::set_d_gain(const double gain_d)
 {
-  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE) {
+    return WheelController::ERROR_INVALID_MODE;
+  }
 
   gain_d_ = gain_d;
   bool send_result;
@@ -191,7 +196,9 @@ WheelController::ErrorCode WheelController::set_pid_gain(
   const double gain_p, const double gain_i,
   const double gain_d)
 {
-  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE) {
+    return WheelController::ERROR_INVALID_MODE;
+  }
 
   gain_p_ = gain_p;
   gain_i_ = gain_i;
@@ -208,7 +215,7 @@ WheelController::ErrorCode WheelController::set_pid_gain(
 WheelController::ErrorCode WheelController::debug_set_wheel_velocities(
   const double vel_front_right, const double vel_front_left, const double vel_back_center)
 {
-  if (this->mode_ != WheelController::DEBUG_MODE) return WheelController::ERROR_INVALID_MODE;
+  if (this->mode_ != WheelController::DEBUG_MODE) {return WheelController::ERROR_INVALID_MODE;}
   return this->set_wheel_velocities_(vel_front_right, vel_front_left, vel_back_center);
 }
 
@@ -270,7 +277,7 @@ double WheelController::constrain(const double value, const double min, const do
 }
 
 WheelController::ErrorCode WheelController::set_wheel_velocities_(
-    const double vel_front_right, const double vel_front_left, const double vel_back_center)
+  const double vel_front_right, const double vel_front_left, const double vel_back_center)
 {
   constexpr double LSB = 100;  // 送信データの1bitが、車輪速度の100倍を表す
 

--- a/frootspi_hardware/src/wheel_controller.cpp
+++ b/frootspi_hardware/src/wheel_controller.cpp
@@ -33,7 +33,7 @@ WheelController::WheelController()
 : socket_(-1),
   vel_front_right_(0.0), vel_front_left_(0.0), vel_back_center_(0.0),
   gain_p_(0.0), gain_i_(0.0), gain_d_(0.0),
-  is_gain_setting_enabled_(false)
+  mode_(WheelController::Mode::NORMAL_MODE)
 {
 }
 
@@ -87,40 +87,8 @@ bool WheelController::device_close()
 WheelController::ErrorCode WheelController::set_wheel_velocities(
   const double vel_front_right, const double vel_front_left, const double vel_back_center)
 {
-  constexpr double LSB = 100;  // 送信データの1bitが、車輪速度の100倍を表す
-
-  if (is_gain_setting_enabled_) {
-    return WheelController::ERROR_GAIN_SETTING_MODE_ENABLED;
-  }
-
-  // インスタンス変数に現在の速度を保存
-  vel_front_right_ = vel_front_right;
-  vel_front_left_ = vel_front_left;
-  vel_back_center_ = vel_back_center;
-
-  int16_t motor_vel_right = vel_front_right * LSB;
-  int16_t motor_vel_left = vel_front_left * LSB;
-  int16_t motor_vel_center = vel_back_center * LSB;
-
-  struct can_frame frame;
-  frame.can_id = 0x1aa;
-  frame.can_dlc = 8;
-  frame.data[0] = 0xAA;
-  frame.data[1] = 0xAA;
-  frame.data[2] = 0xFF & motor_vel_left;
-  frame.data[3] = 0xFF & (motor_vel_left >> 8);
-  frame.data[4] = 0xFF & motor_vel_center;
-  frame.data[5] = 0xFF & (motor_vel_center >> 8);
-  frame.data[6] = 0xFF & motor_vel_right;
-  frame.data[7] = 0xFF & (motor_vel_right >> 8);
-
-  bool can_result;
-  can_result = send_can(frame);
-
-  if (!can_result) {
-    return WheelController::ERROR_CAN_SEND_FAILED;
-  }
-  return WheelController::ERROR_NONE;
+  if (this->mode_ != WheelController::NORMAL_MODE) return WheelController::ERROR_INVALID_MODE;
+  return this->set_wheel_velocities_(vel_front_right, vel_front_left, vel_back_center);
 }
 
 
@@ -129,48 +97,31 @@ bool WheelController::is_motor_stopping()
   return (vel_front_right_ == 0.0) && (vel_front_left_ == 0.0) && (vel_back_center_ == 0.0);
 }
 
-/**
- * @brief ゲイン設定モードを有効にする
- * @return エラーコード
- * @retval WheelController::ERROR_NONE 成功
- * @retval WheelController::ERROR_WHEELS_ARE_MOVING 車輪が動いているため、ゲイン設定モードを有効にできない
-*/
-WheelController::ErrorCode WheelController::enable_gain_setting()
+WheelController::ErrorCode WheelController::set_mode(WheelController::Mode mode)
 {
-  // 車輪が停止していたらenableできる
+  // 車輪が停止していないと設定できない
   if (!is_motor_stopping()) {
-    RCLCPP_ERROR(LOGGER, "車輪が停止していないため、ゲイン設定を有効にできません");
+    RCLCPP_ERROR(LOGGER, "車輪が停止していないため、モードを切り替えられません");
     return WheelController::ERROR_WHEELS_ARE_MOVING;
   }
 
-  is_gain_setting_enabled_ = true;
+  this->mode_ = mode;
   return WheelController::ERROR_NONE;
 }
 
-/**
- * @brief ゲイン設定モードを無効にする
- * @return エラーコード
- * @retval WheelController::ERROR_NONE 成功
-*/
-WheelController::ErrorCode WheelController::disable_gain_setting()
-{
-  is_gain_setting_enabled_ = false;
-  return WheelController::ERROR_NONE;
-}
+
 
 /**
  * @brief Pゲインを設定する
  * @param[in] gain_p Pゲイン
  * @return エラーコード
  * @retval WheelController::ERROR_NONE 成功
- * @retval WheelController::ERROR_GAIN_SETTING_MODE_DISABLED ゲイン設定モードが無効のため、ゲインを設定できない
+ * @retval WheelController::ERROR_INVALID_MODE モードがゲイン設定モードでないため、ゲインを設定できない
  * @retval WheelController::ERROR_CAN_SEND_FAILED CAN送信に失敗した
 */
 WheelController::ErrorCode WheelController::set_p_gain(const double gain_p)
 {
-  if (!is_gain_setting_enabled_) {
-    return WheelController::ERROR_GAIN_SETTING_MODE_DISABLED;
-  }
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
 
   gain_p_ = gain_p;
   bool send_result;
@@ -187,14 +138,12 @@ WheelController::ErrorCode WheelController::set_p_gain(const double gain_p)
  * @param[in] gain_i Iゲイン
  * @return エラーコード
  * @retval WheelController::ERROR_NONE 成功
- * @retval WheelController::ERROR_GAIN_SETTING_MODE_DISABLED ゲイン設定モードが無効のため、ゲインを設定できない
+ * @retval WheelController::ERROR_INVALID_MODE モードがゲイン設定モードでないため、ゲインを設定できない
  * @retval WheelController::ERROR_CAN_SEND_FAILED CAN送信に失敗した
 */
 WheelController::ErrorCode WheelController::set_i_gain(const double gain_i)
 {
-  if (!is_gain_setting_enabled_) {
-    return WheelController::ERROR_GAIN_SETTING_MODE_DISABLED;
-  }
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
 
   gain_i_ = gain_i;
   bool send_result;
@@ -211,14 +160,12 @@ WheelController::ErrorCode WheelController::set_i_gain(const double gain_i)
  * @param[in] gain_d Dゲイン
  * @return エラーコード
  * @retval WheelController::ERROR_NONE 成功
- * @retval WheelController::ERROR_GAIN_SETTING_MODE_DISABLED ゲイン設定モードが無効のため、ゲインを設定できない
+ * @retval WheelController::ERROR_INVALID_MODE モードがゲイン設定モードでないため、ゲインを設定できない
  * @retval WheelController::ERROR_CAN_SEND_FAILED CAN送信に失敗した
 */
 WheelController::ErrorCode WheelController::set_d_gain(const double gain_d)
 {
-  if (!is_gain_setting_enabled_) {
-    return WheelController::ERROR_GAIN_SETTING_MODE_DISABLED;
-  }
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
 
   gain_d_ = gain_d;
   bool send_result;
@@ -237,16 +184,14 @@ WheelController::ErrorCode WheelController::set_d_gain(const double gain_d)
  * @param[in] gain_d Dゲイン
  * @return エラーコード
  * @retval WheelController::ERROR_NONE 成功
- * @retval WheelController::ERROR_GAIN_SETTING_MODE_DISABLED ゲイン設定モードが無効のため、ゲインを設定できない
+ * @retval WheelController::ERROR_INVALID_MODE モードがゲイン設定モードでないため、ゲインを設定できない
  * @retval WheelController::ERROR_CAN_SEND_FAILED CAN送信に失敗した
 */
 WheelController::ErrorCode WheelController::set_pid_gain(
   const double gain_p, const double gain_i,
   const double gain_d)
 {
-  if (!is_gain_setting_enabled_) {
-    return WheelController::ERROR_GAIN_SETTING_MODE_DISABLED;
-  }
+  if (this->mode_ != WheelController::GAIN_SETTING_MODE)  return WheelController::ERROR_INVALID_MODE;
 
   gain_p_ = gain_p;
   gain_i_ = gain_i;
@@ -258,6 +203,13 @@ WheelController::ErrorCode WheelController::set_pid_gain(
     return WheelController::ERROR_CAN_SEND_FAILED;
   }
   return WheelController::ERROR_NONE;
+}
+
+WheelController::ErrorCode WheelController::debug_set_wheel_velocities(
+  const double vel_front_right, const double vel_front_left, const double vel_back_center)
+{
+  if (this->mode_ != WheelController::DEBUG_MODE) return WheelController::ERROR_INVALID_MODE;
+  return this->set_wheel_velocities_(vel_front_right, vel_front_left, vel_back_center);
 }
 
 bool WheelController::send_pid_gain()
@@ -315,4 +267,39 @@ double WheelController::constrain(const double value, const double min, const do
   } else {
     return value;
   }
+}
+
+WheelController::ErrorCode WheelController::set_wheel_velocities_(
+    const double vel_front_right, const double vel_front_left, const double vel_back_center)
+{
+  constexpr double LSB = 100;  // 送信データの1bitが、車輪速度の100倍を表す
+
+  // インスタンス変数に現在の速度を保存
+  vel_front_right_ = vel_front_right;
+  vel_front_left_ = vel_front_left;
+  vel_back_center_ = vel_back_center;
+
+  int16_t motor_vel_right = vel_front_right * LSB;
+  int16_t motor_vel_left = vel_front_left * LSB;
+  int16_t motor_vel_center = vel_back_center * LSB;
+
+  struct can_frame frame;
+  frame.can_id = 0x1aa;
+  frame.can_dlc = 8;
+  frame.data[0] = 0xAA;
+  frame.data[1] = 0xAA;
+  frame.data[2] = 0xFF & motor_vel_left;
+  frame.data[3] = 0xFF & (motor_vel_left >> 8);
+  frame.data[4] = 0xFF & motor_vel_center;
+  frame.data[5] = 0xFF & (motor_vel_center >> 8);
+  frame.data[6] = 0xFF & motor_vel_right;
+  frame.data[7] = 0xFF & (motor_vel_right >> 8);
+
+  bool can_result;
+  can_result = send_can(frame);
+
+  if (!can_result) {
+    return WheelController::ERROR_CAN_SEND_FAILED;
+  }
+  return WheelController::ERROR_NONE;
 }

--- a/frootspi_kicker/include/frootspi_kicker/frootspi_kicker_component.hpp
+++ b/frootspi_kicker/include/frootspi_kicker/frootspi_kicker_component.hpp
@@ -21,7 +21,6 @@
 #include "std_msgs/msg/int16.hpp"
 #include "frootspi_msgs/msg/battery_voltage.hpp"
 #include "frootspi_msgs/msg/ball_detection.hpp"
-#include "frootspi_msgs/msg/switches_state.hpp"
 #include "frootspi_msgs/msg/kick_command.hpp"
 #include "frootspi_msgs/srv/kick.hpp"
 #include "frootspi_msgs/srv/set_kicker_charging.hpp"
@@ -44,7 +43,6 @@ private:
 
   // subscribers
   rclcpp::Subscription<frootspi_msgs::msg::BallDetection>::SharedPtr sub_ball_detection_;
-  rclcpp::Subscription<frootspi_msgs::msg::SwitchesState>::SharedPtr sub_switch_state_;
   rclcpp::Subscription<frootspi_msgs::msg::BatteryVoltage>::SharedPtr sub_kicker_voltage_;
   rclcpp::Subscription<frootspi_msgs::msg::KickCommand>::SharedPtr sub_kick_command_;
   // servers
@@ -56,7 +54,6 @@ private:
 
   // subscription callbacks
   void callback_ball_detection(const frootspi_msgs::msg::BallDetection::SharedPtr msg);
-  void callback_switch_state(const frootspi_msgs::msg::SwitchesState::SharedPtr msg);
   void callback_kicker_voltage(const frootspi_msgs::msg::BatteryVoltage::SharedPtr msg);
   void callback_kick_command(const frootspi_msgs::msg::KickCommand::SharedPtr msg);
 
@@ -83,7 +80,6 @@ private:
   float capacitor_voltage_;
   bool set_charge_enable_;
   bool set_charge_enable_pre_;
-  frootspi_msgs::msg::SwitchesState switches_state_;
 };
 
 }  // namespace frootspi_kicker

--- a/frootspi_kicker/src/frootspi_kicker_component.cpp
+++ b/frootspi_kicker/src/frootspi_kicker_component.cpp
@@ -177,8 +177,7 @@ void KickerNode::on_capacitor_charge_request(
     charge_enable_from_conductor_ = false;
   }
 
-  if ((charge_enable_from_conductor_ == true) && (is_kicking_ == false))
-  {
+  if ((charge_enable_from_conductor_ == true) && (is_kicking_ == false)) {
     charge_enable = true;
   } else {
     charge_enable = false;


### PR DESCRIPTION
動作確認のためのテストモードを実装しました。

FrootsPi基板のスイッチを押して、車輪、ドリブラー、キッカーのテストができます。  

スイッチと機能の割り当ては次の通りです。スイッチは本体後方から見たときの左からの順番です。
- 1番目：なし（シャットダウンスイッチのため)
- 2番目：車輪　押している間だけ車輪が回転
- 3番目：ドリブラー　押している間だけドリブラーが回転
- 4番目：充電　押している間だけキッカー充電
- 5番目：放電　押したら放電開始